### PR TITLE
Add minimal API with health check and problem details handling

### DIFF
--- a/HomeschoolPlanner.Api/HomeschoolPlanner.Api.csproj
+++ b/HomeschoolPlanner.Api/HomeschoolPlanner.Api.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/HomeschoolPlanner.Api/Middleware/ProblemDetailsMiddleware.cs
+++ b/HomeschoolPlanner.Api/Middleware/ProblemDetailsMiddleware.cs
@@ -1,0 +1,56 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace HomeschoolPlanner.Api.Middleware;
+
+public class ProblemDetailsMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<ProblemDetailsMiddleware> _logger;
+
+    public ProblemDetailsMiddleware(RequestDelegate next, ILogger<ProblemDetailsMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception");
+
+            var problem = new ProblemDetails
+            {
+                Title = "An unexpected error occurred.",
+                Status = StatusCodes.Status500InternalServerError,
+                Detail = ex.Message
+            };
+
+            context.Response.StatusCode = problem.Status.Value;
+            context.Response.ContentType = "application/problem+json";
+
+            await context.Response.WriteAsJsonAsync(problem);
+            return;
+        }
+
+        if (!context.Response.HasStarted &&
+            context.Response.StatusCode >= 400 &&
+            context.Response.ContentLength is null &&
+            string.IsNullOrEmpty(context.Response.ContentType))
+        {
+            var problem = new ProblemDetails
+            {
+                Status = context.Response.StatusCode,
+                Title = ReasonPhrases.GetReasonPhrase(context.Response.StatusCode)
+            };
+
+            context.Response.ContentType = "application/problem+json";
+            await context.Response.WriteAsJsonAsync(problem);
+        }
+    }
+}

--- a/HomeschoolPlanner.Api/Program.cs
+++ b/HomeschoolPlanner.Api/Program.cs
@@ -1,0 +1,18 @@
+using HomeschoolPlanner.Api.Middleware;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddProblemDetails();
+
+var app = builder.Build();
+
+app.UseMiddleware<ProblemDetailsMiddleware>();
+
+app.MapGet("/healthz", () => Results.Json(new { status = "ok" }));
+
+app.MapGet("/error", () =>
+{
+    throw new InvalidOperationException("Test exception");
+});
+
+app.Run();


### PR DESCRIPTION
## Summary
- Scaffold HomeschoolPlanner.Api minimal API targeting .NET 8
- Add `/healthz` endpoint
- Implement middleware for RFC7807 problem+json responses with centralized exception handling

## Testing
- `dotnet build HomeschoolPlanner.Api` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68ad31cada1c8321b9b9579c599b9116