### PR TITLE
Add resource entity and bulk unit endpoint

### DIFF
--- a/AgentNotes/2025-09-02T18-38-08Z-resources-bulk-units.md
+++ b/AgentNotes/2025-09-02T18-38-08Z-resources-bulk-units.md
@@ -1,0 +1,32 @@
+## Task
+Resources: entity + Create + Bulk Units
+- Why: Subjects need assignables (book/time/custom).
+- Add:
+   - Entities/Resource.cs (Id, SubjectId, Type enum Book|Time|Custom, Title, MinutesPerOccurrence?, MaxUnitsPerDay?)
+   - Entities/ResourceUnit.cs (Id, ResourceId, Index:int, Label) with unique index (ResourceId, Index).
+- DbContext: DbSet<Resource>, DbSet<ResourceUnit>.
+- Endpoints:
+   - POST /api/v1/resources → create.
+   - POST /api/v1/resources/{id}/units/bulk → accept labels: string[], create sequential units starting at 1.
+- DoD: Create a resource and bulk in e.g. 10 units; list via a simple GET on resource (optional) or check DB via subsequent schedule call.
+
+## Initial considerations
+* Need to define Resource and ResourceUnit entities with relationships and type enum.
+* Need DbContext entries and configuration, including unique index on (ResourceId, Index).
+* Implement endpoints for creating resources and bulk adding units.
+* Need to handle validation: subject must exist? maybe using foreign keys.
+* Ensure sequential index starts at 1 for units; when bulk insertion, index increments from existing count + 1? The spec says starting at 1 when creating sequential units - but should always start at 1; maybe just create new units with indexes starting at 1 ignoring existing units? But to support multiple bulk calls we should continue from existing count + 1, but spec may not require. Possibly next call should continue sequential; we will implement to start after existing units (so from existing count + 1).
+* Need to add migrations for new entities.
+* Implement tests: integration tests for creating resource and bulk units? DoD indicates manual check; but repo instructions emphasise `dotnet test`. We'll add tests verifying resource creation and bulk units maybe.
+* Must run dotnet restore/build/test, create EF migration.
+
+## Work log
+* Created Resource and ResourceUnit entity files and removed inline definitions from AppDbContext.
+* Added ResourceEndpoints for create and bulk unit operations; uncommented routes in Program.cs.
+* Updated requests.http with resource examples.
+* Added integration test covering resource creation and bulk units.
+* Installed .NET SDK and dotnet-ef; ran restore/build/test and database update.
+
+## Results
+* Resource creation and bulk unit endpoints work; tests pass.
+* Confidence: ~0.86.

--- a/HomeschoolPlanner.Api.Tests/ResourceTests.cs
+++ b/HomeschoolPlanner.Api.Tests/ResourceTests.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using System.Net.Http.Json;
+using HomeschoolPlanner.Data;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+
+namespace HomeschoolPlanner.Api.Tests;
+
+public class ResourceTests
+{
+    [Fact]
+    public async Task Resource_Create_and_BulkUnits_roundtrip()
+    {
+        Environment.SetEnvironmentVariable("DB_PROVIDER", "InMemory");
+        await using var app = new WebApplicationFactory<Program>();
+        var client = app.CreateClient();
+
+        var learnerResp = await client.PostAsJsonAsync("/api/v1/learners", new { name = "Eve", grade = "6" });
+        learnerResp.EnsureSuccessStatusCode();
+        var learner = await learnerResp.Content.ReadFromJsonAsync<Learner>();
+
+        var subjectResp = await client.PostAsJsonAsync("/api/v1/subjects", new { learnerId = learner!.Id, title = "Science" });
+        subjectResp.EnsureSuccessStatusCode();
+        var subject = await subjectResp.Content.ReadFromJsonAsync<Subject>();
+
+        var resourceResp = await client.PostAsJsonAsync("/api/v1/resources", new { subjectId = subject!.Id, type = ResourceType.Book, title = "Biology" });
+        resourceResp.EnsureSuccessStatusCode();
+        var resource = await resourceResp.Content.ReadFromJsonAsync<Resource>();
+
+        var labels = Enumerable.Range(1, 10).Select(i => $"Lesson {i}").ToArray();
+        var bulkResp = await client.PostAsJsonAsync($"/api/v1/resources/{resource!.Id}/units/bulk", labels);
+        bulkResp.EnsureSuccessStatusCode();
+
+        using var scope = app.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        var count = await db.ResourceUnits.CountAsync(u => u.ResourceId == resource!.Id);
+        Assert.Equal(10, count);
+    }
+}

--- a/HomeschoolPlanner.Api/Data/AppDbContext.cs
+++ b/HomeschoolPlanner.Api/Data/AppDbContext.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using System.Collections.Generic;
-using System.Reflection.Emit;
 
 namespace HomeschoolPlanner.Data;
 
@@ -43,26 +41,6 @@ public class User
     public string Email { get; set; } = "";
     public byte[] PasswordHash { get; set; } = Array.Empty<byte>(); // placeholder
     public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
-}
-
-public enum ResourceType { Book = 1, Time = 2, Custom = 3 }
-
-public class Resource
-{
-    public Guid Id { get; set; }
-    public Guid SubjectId { get; set; }
-    public ResourceType Type { get; set; }
-    public string Title { get; set; } = "";
-    public int? MinutesPerOccurrence { get; set; }   // for Time resources
-    public int? MaxUnitsPerDay { get; set; }         // pacing guardrail
-}
-
-public class ResourceUnit
-{
-    public Guid Id { get; set; }
-    public Guid ResourceId { get; set; }
-    public int Index { get; set; }                   // 1..N (chapter/lesson/etc)
-    public string Label { get; set; } = "";          // "Lesson 12"
 }
 
 public class Plan

--- a/HomeschoolPlanner.Api/Endpoints/Resources.cs
+++ b/HomeschoolPlanner.Api/Endpoints/Resources.cs
@@ -1,0 +1,50 @@
+using HomeschoolPlanner.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace HomeschoolPlanner.Api.Endpoints;
+
+public static class ResourceEndpoints
+{
+    public static async Task<IResult> Create(AppDbContext db, Resource dto)
+    {
+        if (string.IsNullOrWhiteSpace(dto.Title))
+            return Results.BadRequest(new { error = "Title is required" });
+
+        var subjectExists = await db.Subjects.AnyAsync(s => s.Id == dto.SubjectId);
+        if (!subjectExists)
+            return Results.BadRequest(new { error = "Subject not found" });
+
+        dto.Id = Guid.NewGuid();
+        db.Resources.Add(dto);
+        await db.SaveChangesAsync();
+
+        return Results.Created($"/api/v1/resources/{dto.Id}", dto);
+    }
+
+    public static async Task<IResult> BulkUnits(Guid id, string[] labels, AppDbContext db)
+    {
+        if (labels == null || labels.Length == 0)
+            return Results.BadRequest(new { error = "Labels are required" });
+
+        var resource = await db.Resources.FindAsync(id);
+        if (resource == null)
+            return Results.NotFound();
+
+        var existing = await db.ResourceUnits
+            .Where(u => u.ResourceId == id)
+            .CountAsync();
+
+        var units = labels.Select((label, i) => new ResourceUnit
+        {
+            Id = Guid.NewGuid(),
+            ResourceId = id,
+            Index = existing + i + 1,
+            Label = label
+        }).ToList();
+
+        db.ResourceUnits.AddRange(units);
+        await db.SaveChangesAsync();
+
+        return Results.Ok(units);
+    }
+}

--- a/HomeschoolPlanner.Api/Entities/Resource.cs
+++ b/HomeschoolPlanner.Api/Entities/Resource.cs
@@ -1,0 +1,13 @@
+namespace HomeschoolPlanner.Data;
+
+public enum ResourceType { Book = 1, Time = 2, Custom = 3 }
+
+public class Resource
+{
+    public Guid Id { get; set; }
+    public Guid SubjectId { get; set; }
+    public ResourceType Type { get; set; }
+    public string Title { get; set; } = "";
+    public int? MinutesPerOccurrence { get; set; }
+    public int? MaxUnitsPerDay { get; set; }
+}

--- a/HomeschoolPlanner.Api/Entities/ResourceUnit.cs
+++ b/HomeschoolPlanner.Api/Entities/ResourceUnit.cs
@@ -1,0 +1,9 @@
+namespace HomeschoolPlanner.Data;
+
+public class ResourceUnit
+{
+    public Guid Id { get; set; }
+    public Guid ResourceId { get; set; }
+    public int Index { get; set; }
+    public string Label { get; set; } = "";
+}

--- a/HomeschoolPlanner.Api/Program.cs
+++ b/HomeschoolPlanner.Api/Program.cs
@@ -122,8 +122,8 @@ v1.MapGet("/subjects", SubjectEndpoints.List);
 v1.MapPost("/subjects", SubjectEndpoints.Create);
 
 //// Resources (+units)
-//v1.MapPost("/resources", ResourceEndpoints.Create);
-//v1.MapPost("/resources/{id:guid}/units/bulk", ResourceEndpoints.BulkUnits);
+v1.MapPost("/resources", ResourceEndpoints.Create);
+v1.MapPost("/resources/{id:guid}/units/bulk", ResourceEndpoints.BulkUnits);
 
 //// Plans (+ schedule materialization)
 //v1.MapPost("/plans", PlanEndpoints.Create);

--- a/requests.http
+++ b/requests.http
@@ -20,3 +20,15 @@ Content-Type: application/json
 
 ### List subjects
 GET http://localhost:5137/api/v1/subjects?learnerId=<REPLACE_WITH_LEARNER_ID>
+
+### Create resource
+POST http://localhost:5137/api/v1/resources
+Content-Type: application/json
+
+{ "subjectId": "<REPLACE_WITH_SUBJECT_ID>", "type": 1, "title": "Algebra" }
+
+### Bulk add resource units
+POST http://localhost:5137/api/v1/resources/<REPLACE_WITH_RESOURCE_ID>/units/bulk
+Content-Type: application/json
+
+["Lesson 1", "Lesson 2"]


### PR DESCRIPTION
## Summary
- add `Resource` and `ResourceUnit` entities
- enable creating resources and bulk-adding units
- cover resource flow with integration test and HTTP samples

## Testing
- `dotnet restore`
- `dotnet build --no-restore -c Release`
- `dotnet test --no-build -c Release`
- `dotnet ef database update --project HomeschoolPlanner.Api --startup-project HomeschoolPlanner.Api`


------
https://chatgpt.com/codex/tasks/task_e_68b7396ec328832ea488eb0d4331f467