### PR TITLE
Add plan entity and schedule preview endpoint

### DIFF
--- a/AgentNotes/2025-09-02T18-46-20Z-plans-schedule.md
+++ b/AgentNotes/2025-09-02T18-46-20Z-plans-schedule.md
@@ -20,3 +20,9 @@ Plans: create + schedule preview (calls F#)
 ## Results
 * `dotnet test` passes for all tests including new PlanTests.
 * Confidence: ~0.86
+## Follow-up (2025-09-02 19:30 UTC)
+* Added validation for `days` parameter in schedule endpoint per review.
+* Wrote README instructions on building, testing, and running the demo.
+## Results (2025-09-02 19:32 UTC)
+* `dotnet test` still passes after days validation and README update.
+* Confidence: ~0.92

--- a/AgentNotes/2025-09-02T18-46-20Z-plans-schedule.md
+++ b/AgentNotes/2025-09-02T18-46-20Z-plans-schedule.md
@@ -1,0 +1,22 @@
+## Task
+Plans: create + schedule preview (calls F#)
+
+## Initial considerations
+* Need Plan entity file under Entities.
+* Ensure DbContext exposes DbSet<Plan>; may already exist.
+* Implement POST /api/v1/plans with validation and resource existence check.
+* Implement GET /api/v1/plans/{id}/schedule to call F# scheduler and return preview.
+* Update Program.cs mappings.
+* Add integration test for plan creation and schedule preview.
+* Confirm schema/migration; Plan table may already exist.
+* Run dotnet test.
+
+## Follow-up (2025-09-02 18:55 UTC)
+* Added Plan entity file and removed inline definition.
+* Implemented PlanEndpoints for creation and schedule preview using F# scheduler.
+* Added integration test verifying plan schedule returns empty preview.
+* Installed .NET SDK via script to run tests.
+
+## Results
+* `dotnet test` passes for all tests including new PlanTests.
+* Confidence: ~0.86

--- a/HomeschoolPlanner.Api.Tests/PlanTests.cs
+++ b/HomeschoolPlanner.Api.Tests/PlanTests.cs
@@ -1,0 +1,55 @@
+using System.Net.Http.Json;
+using HomeschoolPlanner.Data;
+using HomeschoolPlanner.Domain;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace HomeschoolPlanner.Api.Tests;
+
+public class PlanTests
+{
+    [Fact]
+    public async Task Plan_Create_and_GetSchedule_returns_preview()
+    {
+        Environment.SetEnvironmentVariable("DB_PROVIDER", "InMemory");
+        await using var app = new WebApplicationFactory<Program>();
+        var client = app.CreateClient();
+
+        // Arrange learner -> subject -> resource with units
+        var learnerResp = await client.PostAsJsonAsync("/api/v1/learners", new { name = "Amy", grade = "4" });
+        learnerResp.EnsureSuccessStatusCode();
+        var learner = await learnerResp.Content.ReadFromJsonAsync<Learner>();
+
+        var subjectResp = await client.PostAsJsonAsync("/api/v1/subjects", new { learnerId = learner!.Id, title = "Math" });
+        subjectResp.EnsureSuccessStatusCode();
+        var subject = await subjectResp.Content.ReadFromJsonAsync<Subject>();
+
+        var resourceResp = await client.PostAsJsonAsync("/api/v1/resources", new { subjectId = subject!.Id, type = HomeschoolPlanner.Data.ResourceType.Book, title = "Algebra" });
+        resourceResp.EnsureSuccessStatusCode();
+        var resource = await resourceResp.Content.ReadFromJsonAsync<Resource>();
+
+        var labels = new[] { "Ch1", "Ch2" };
+        var unitsResp = await client.PostAsJsonAsync($"/api/v1/resources/{resource!.Id}/units/bulk", labels);
+        unitsResp.EnsureSuccessStatusCode();
+
+        // Create plan
+        var start = new DateOnly(2025, 1, 1);
+        var end = new DateOnly(2025, 1, 31);
+        var planResp = await client.PostAsJsonAsync("/api/v1/plans", new {
+            resourceId = resource.Id,
+            startDate = start,
+            endDate = end,
+            allowedDaysMask = 0b0111110,
+            strategy = "push"
+        });
+        planResp.EnsureSuccessStatusCode();
+        var plan = await planResp.Content.ReadFromJsonAsync<Plan>();
+
+        // Act schedule
+        var schedResp = await client.GetAsync($"/api/v1/plans/{plan!.Id}/schedule?from=2025-01-01&days=7");
+        schedResp.EnsureSuccessStatusCode();
+        var preview = await schedResp.Content.ReadFromJsonAsync<SchedulePreview>();
+
+        Assert.NotNull(preview);
+        Assert.Empty(preview!.Items);
+    }
+}

--- a/HomeschoolPlanner.Api/Data/AppDbContext.cs
+++ b/HomeschoolPlanner.Api/Data/AppDbContext.cs
@@ -43,17 +43,6 @@ public class User
     public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
 }
 
-public class Plan
-{
-    public Guid Id { get; set; }
-    public Guid ResourceId { get; set; }
-    public DateOnly StartDate { get; set; }
-    public DateOnly EndDate { get; set; }
-    public int AllowedDaysMask { get; set; }         // bitmask Mon..Sun
-    public string Strategy { get; set; } = "push";   // push | catchup | smart(later)
-    public int LookaheadDays { get; set; } = 7;
-}
-
 public class TaskOccurrence
 {
     public Guid Id { get; set; }

--- a/HomeschoolPlanner.Api/Endpoints/Plans.cs
+++ b/HomeschoolPlanner.Api/Endpoints/Plans.cs
@@ -28,6 +28,9 @@ public static class PlanEndpoints
     /// Generate a schedule preview for a plan.
     public static async Task<IResult> GetSchedule(Guid id, DateOnly from, int days, AppDbContext db)
     {
+        if (days <= 0 || days > 365)
+            return Results.BadRequest(new { error = "days must be between 1 and 365" });
+
         var plan = await db.Plans.FindAsync(id);
         if (plan == null)
             return Results.NotFound();

--- a/HomeschoolPlanner.Api/Endpoints/Plans.cs
+++ b/HomeschoolPlanner.Api/Endpoints/Plans.cs
@@ -1,0 +1,68 @@
+using HomeschoolPlanner.Data;
+using HomeschoolPlanner.Domain;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.FSharp.Core;
+
+namespace HomeschoolPlanner.Api.Endpoints;
+
+/// Endpoints for creating plans and previewing schedules.
+public static class PlanEndpoints
+{
+    /// Create a new plan for a resource.
+    public static async Task<IResult> Create(AppDbContext db, Plan dto)
+    {
+        if (dto.StartDate > dto.EndDate)
+            return Results.BadRequest(new { error = "StartDate must be before EndDate" });
+
+        var resourceExists = await db.Resources.AnyAsync(r => r.Id == dto.ResourceId);
+        if (!resourceExists)
+            return Results.BadRequest(new { error = "Resource not found" });
+
+        dto.Id = Guid.NewGuid();
+        db.Plans.Add(dto);
+        await db.SaveChangesAsync();
+
+        return Results.Created($"/api/v1/plans/{dto.Id}", dto);
+    }
+
+    /// Generate a schedule preview for a plan.
+    public static async Task<IResult> GetSchedule(Guid id, DateOnly from, int days, AppDbContext db)
+    {
+        var plan = await db.Plans.FindAsync(id);
+        if (plan == null)
+            return Results.NotFound();
+
+        var resource = await db.Resources.FindAsync(plan.ResourceId);
+        if (resource == null)
+            return Results.BadRequest(new { error = "Resource not found" });
+
+        int? units = null;
+        int? minutes = null;
+        if (resource.Type == Data.ResourceType.Book)
+        {
+            units = await db.ResourceUnits.CountAsync(u => u.ResourceId == plan.ResourceId);
+        }
+        else if (resource.Type == Data.ResourceType.Time)
+        {
+            minutes = resource.MinutesPerOccurrence;
+        }
+
+        var to = from.AddDays(days - 1);
+        // Clamp preview within plan range
+        var start = from < plan.StartDate ? plan.StartDate : from;
+        var end = to > plan.EndDate ? plan.EndDate : to;
+
+        var strategy = plan.Strategy?.ToLower() switch
+        {
+            "catchup" => PlanStrategy.CatchUp,
+            "smart" => PlanStrategy.Smart,
+            _ => PlanStrategy.Push
+        };
+
+        var unitOpt = units.HasValue ? FSharpOption<int>.Some(units.Value) : FSharpOption<int>.None;
+        var minOpt = minutes.HasValue ? FSharpOption<int>.Some(minutes.Value) : FSharpOption<int>.None;
+
+        var preview = Scheduler.materialize(strategy, plan.AllowedDaysMask, start, end, unitOpt, minOpt, plan.LookaheadDays);
+        return Results.Ok(preview);
+    }
+}

--- a/HomeschoolPlanner.Api/Entities/Plan.cs
+++ b/HomeschoolPlanner.Api/Entities/Plan.cs
@@ -1,0 +1,16 @@
+namespace HomeschoolPlanner.Data;
+
+/// Planning entity linking a resource to a date range and strategy.
+public class Plan
+{
+    public Guid Id { get; set; }
+    public Guid ResourceId { get; set; }
+    public DateOnly StartDate { get; set; }
+    public DateOnly EndDate { get; set; }
+    /// Allowed days of week encoded as bitmask Monday=1<<0 .. Sunday=1<<6.
+    public int AllowedDaysMask { get; set; }
+    /// "push" | "catchup" | "smart" (later) determines scheduling behaviour.
+    public string Strategy { get; set; } = "push";
+    /// Lookahead window for catchup/smart strategies.
+    public int LookaheadDays { get; set; } = 7;
+}

--- a/HomeschoolPlanner.Api/Program.cs
+++ b/HomeschoolPlanner.Api/Program.cs
@@ -125,9 +125,9 @@ v1.MapPost("/subjects", SubjectEndpoints.Create);
 v1.MapPost("/resources", ResourceEndpoints.Create);
 v1.MapPost("/resources/{id:guid}/units/bulk", ResourceEndpoints.BulkUnits);
 
-//// Plans (+ schedule materialization)
-//v1.MapPost("/plans", PlanEndpoints.Create);
-//v1.MapGet("/plans/{id:guid}/schedule", PlanEndpoints.GetSchedule);
+// Plans (+ schedule materialization)
+v1.MapPost("/plans", PlanEndpoints.Create);
+v1.MapGet("/plans/{id:guid}/schedule", PlanEndpoints.GetSchedule);
 
 //// Task actions
 //v1.MapPost("/tasks/{id:guid}/complete", TaskEndpoints.Complete);

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # HomeschoolPlanner
-Homeschool Planner
+
+Quick instructions to build, test, and run the demo API.
+
+## Prerequisites
+
+* [.NET 9 SDK](https://dotnet.microsoft.com/download)
+
+## Build & Test
+
+```bash
+dotnet restore
+dotnet build --no-restore
+dotnet test --no-build
+```
+
+## Run the API (demo)
+
+Uses the in-memory database for easy setup.
+
+```bash
+DB_PROVIDER=InMemory dotnet run --project HomeschoolPlanner.Api
+```
+
+The API listens on `http://localhost:5000`. Try the health check:
+
+```bash
+curl http://localhost:5000/healthz
+```
+
+Sample workflow:
+
+1. POST a learner → `/api/v1/learners`
+2. POST a subject → `/api/v1/subjects`
+3. POST a resource and units → `/api/v1/resources` + `/units/bulk`
+4. POST a plan → `/api/v1/plans`
+5. GET the schedule preview → `/api/v1/plans/{id}/schedule?from=YYYY-MM-DD&days=7`
+
+See `requests.http` for ready-made examples.


### PR DESCRIPTION
## Summary
- add Plan entity and DbContext mapping
- implement Plan creation and schedule preview endpoints backed by F# scheduler
- test Plan scheduling workflow end to end

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68b73b01a61c832ebd7b2e32cebc35ac