### PR TITLE
Docs: add static demo (week/day)

### DIFF
--- a/AgentNotes/2025-09-06T19-11-27Z-serve-static-demo.md
+++ b/AgentNotes/2025-09-06T19-11-27Z-serve-static-demo.md
@@ -42,3 +42,15 @@ week.html should reflect the Week Preview wireframe (day cards, chips, CTA), and
 * Static demo files are served via new middleware and /demo redirect.
 * Verified pages load and all tests pass.
 * Confidence: 0.9
+## Follow-up (2025-09-06 19:27 UTC)
+* Mirror demo in /docs for GitHub Pages.
+* Copy index, week, day HTML and adjust links to be relative.
+* Run dotnet test and commit.
+## Follow-up (2025-09-06 19:31 UTC)
+* Copied demo HTML into docs/ and updated links to be relative.
+* Added comments to clarify GitHub Pages mirror.
+* Next: run dotnet test.
+## Results
+* Docs folder hosts demo HTML with relative links for GitHub Pages.
+* `dotnet test` failed: .NET 9.0 SDK unavailable in container.
+* Confidence: 0.85

--- a/docs/day.html
+++ b/docs/day.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Day Detail</title>
+  <style>
+    body { font-family: sans-serif; margin: 0; }
+    .timeline { padding: 1rem; }
+    .item { margin-bottom: 1rem; }
+    .time { font-weight: bold; }
+    /* sticky action bar mirrors planned UI */
+    .actions { position: sticky; bottom: 0; background: #fff; padding: 1rem; border-top: 1px solid #ccc; text-align: center; }
+    .actions button { margin: 0 0.5rem; }
+  </style>
+</head>
+<body>
+  <!-- demo day timeline for GitHub Pages -->
+  <h1>Day Detail</h1>
+  <div class="timeline">
+    <div class="item"><span class="time">09:00</span> Math Lesson</div>
+    <div class="item"><span class="time">10:00</span> Reading</div>
+    <div class="item"><span class="time">11:00</span> Science Lab</div>
+  </div>
+  <div class="actions">
+    <button>Complete</button>
+    <button>Skip</button>
+    <button>Extra</button>
+  </div>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Demo Landing</title>
+</head>
+<body>
+  <h1>Homeschool Planner Demo</h1>
+  <nav>
+    <!-- relative links for GitHub Pages -->
+    <ul>
+      <li><a class="demo" href="week.html">Week Preview</a></li>
+      <li><a class="demo" href="day.html">Day Detail</a></li>
+    </ul>
+  </nav>
+</body>
+</html>

--- a/docs/week.html
+++ b/docs/week.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Week Preview</title>
+  <style>
+    body { font-family: sans-serif; }
+    .week { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .day-card { border: 1px solid #ccc; padding: 1rem; width: 120px; border-radius: 8px; }
+    .chips { margin-top: 0.5rem; }
+    .chip { background: #eef; padding: 2px 6px; border-radius: 4px; display: inline-block; margin: 2px 2px 0 0; font-size: 0.8rem; }
+    .link { margin-top: 1rem; display: block; text-align: center; background: #0af; color: white; padding: 0.5rem; border-radius: 4px; text-decoration: none; }
+  </style>
+</head>
+<body>
+  <h1>Week Preview</h1>
+  <div class="week">
+    <div class="day-card">
+      <h2>Mon</h2>
+      <div class="chips">
+        <span class="chip">Math</span>
+        <span class="chip">Reading</span>
+      </div>
+      <!-- relative link to day detail -->
+      <a class="link" href="day.html">Open ▸</a>
+    </div>
+    <div class="day-card">
+      <h2>Tue</h2>
+      <div class="chips">
+        <span class="chip">Science</span>
+        <span class="chip">History</span>
+      </div>
+      <!-- relative link to day detail -->
+      <a class="link" href="day.html">Open ▸</a>
+    </div>
+    <div class="day-card">
+      <h2>Wed</h2>
+      <div class="chips">
+        <span class="chip">Art</span>
+        <span class="chip">Music</span>
+      </div>
+      <!-- relative link to day detail -->
+      <a class="link" href="day.html">Open ▸</a>
+    </div>
+    <div class="day-card">
+      <h2>Thu</h2>
+      <div class="chips">
+        <span class="chip">PE</span>
+        <span class="chip">Math</span>
+      </div>
+      <!-- relative link to day detail -->
+      <a class="link" href="day.html">Open ▸</a>
+    </div>
+    <div class="day-card">
+      <h2>Fri</h2>
+      <div class="chips">
+        <span class="chip">Reading</span>
+        <span class="chip">Science</span>
+      </div>
+      <!-- relative link to day detail -->
+      <a class="link" href="day.html">Open ▸</a>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Mirror demo HTML under `docs/` for GitHub Pages
- Use relative links on landing and week preview pages
- Document day detail with sticky action bar comment

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8ab9f474832e89523173f843c42d