### PR TITLE
Polish demo pages for mobile and sync CSS

### DIFF
--- a/.github/workflows/pages-demo-sync.yml
+++ b/.github/workflows/pages-demo-sync.yml
@@ -18,6 +18,7 @@ jobs:
           cp -f HomeschoolPlanner.Api/wwwroot/demo/index.html docs/index.html
           cp -f HomeschoolPlanner.Api/wwwroot/demo/week.html  docs/week.html
           cp -f HomeschoolPlanner.Api/wwwroot/demo/day.html   docs/day.html
+          cp -f HomeschoolPlanner.Api/wwwroot/demo/demo.css   docs/demo.css
           # make links relative for GitHub Pages
           sed -i 's|href="/demo/week.html"|href="week.html"|g' docs/index.html || true
           sed -i 's|href="/demo/day.html"|href="day.html"|g'   docs/index.html || true

--- a/AgentNotes/2025-09-06T19-11-27Z-serve-static-demo.md
+++ b/AgentNotes/2025-09-06T19-11-27Z-serve-static-demo.md
@@ -70,3 +70,11 @@ week.html should reflect the Week Preview wireframe (day cards, chips, CTA), and
 * Added shared demo.css and updated index/week pages (and docs mirror) to use unified tokens.
 * `dotnet test` succeeded; verified demo assets served via curl.
 * Confidence: 0.88
+## Follow-up (2025-09-06 20:17 UTC)
+* Polish Pages demo for mobile: add theme color & favicon.
+* Ensure demo.css is copied and linked via sync workflow.
+## Results
+* Added theme color meta and SVG favicon to demo index/week (docs and wwwroot) with shared CSS link.
+* Copied demo.css into docs and updated Pages sync workflow to include it.
+* `dotnet test` passed with 4 tests.
+* Confidence: 0.9

--- a/HomeschoolPlanner.Api/wwwroot/demo/index.html
+++ b/HomeschoolPlanner.Api/wwwroot/demo/index.html
@@ -1,7 +1,9 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="theme-color" content="#0b0c10" />
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%23111319'/%3E%3Cpath d='M18 36h28M18 24h20' stroke='%237aa2ff' stroke-width='4' stroke-linecap='round'/%3E%3C/svg%3E" />
+<link rel="stylesheet" href="demo.css" />
 <title>Homeschool Planner — Demos</title>
-<link rel="stylesheet" href="demo.css"/>
 </head><body>
 <!-- demo landing page using centralized tokens -->
 <div class="app">

--- a/HomeschoolPlanner.Api/wwwroot/demo/week.html
+++ b/HomeschoolPlanner.Api/wwwroot/demo/week.html
@@ -1,7 +1,9 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="theme-color" content="#0b0c10" />
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%23111319'/%3E%3Cpath d='M18 36h28M18 24h20' stroke='%237aa2ff' stroke-width='4' stroke-linecap='round'/%3E%3C/svg%3E" />
+<link rel="stylesheet" href="demo.css" />
 <title>Week Preview — Homeschool Planner</title>
-<link rel="stylesheet" href="demo.css"/>
 </head><body>
 <!-- week preview demo using shared tokens -->
 <div class="app">

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,9 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="theme-color" content="#0b0c10" />
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%23111319'/%3E%3Cpath d='M18 36h28M18 24h20' stroke='%237aa2ff' stroke-width='4' stroke-linecap='round'/%3E%3C/svg%3E" />
+<link rel="stylesheet" href="demo.css" />
 <title>Homeschool Planner — Demos</title>
-<link rel="stylesheet" href="demo.css"/>
 </head><body>
 <!-- demo landing page using centralized tokens -->
 <div class="app">

--- a/docs/week.html
+++ b/docs/week.html
@@ -1,7 +1,9 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<meta name="theme-color" content="#0b0c10" />
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%23111319'/%3E%3Cpath d='M18 36h28M18 24h20' stroke='%237aa2ff' stroke-width='4' stroke-linecap='round'/%3E%3C/svg%3E" />
+<link rel="stylesheet" href="demo.css" />
 <title>Week Preview — Homeschool Planner</title>
-<link rel="stylesheet" href="demo.css"/>
 </head><body>
 <!-- week preview demo using shared tokens -->
 <div class="app">


### PR DESCRIPTION
## Summary
- add theme-color meta, favicon, and stylesheet link to demo index and week pages
- copy demo.css during Pages sync so GitHub Pages uses latest styling

## Testing
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68bc964c0cd8832ebad55a86ee29e752