### PR TITLE
feat: show icon in brand and favicon

### DIFF
--- a/AgentNotes/2025-09-09T20-35-00Z-add-icon.md
+++ b/AgentNotes/2025-09-09T20-35-00Z-add-icon.md
@@ -1,0 +1,21 @@
+## Task
+Add Ico image as icon next to Scholar's Forge Planner in header and footer, color box adapts to Scholar/Forge mode, and use same image as webpage tab icon.
+
+## Initial considerations
+* Icon file `images/ico.png` exists.
+* Header/footer located in `docs/index.html`.
+* Favicon needed for marketing pages (`docs/*.html`).
+* Ensure color box keeps theme backgrounds and icon overlays.
+* Run `dotnet test` after changes.
+
+## Follow-up (2025-09-09 20:37 UTC)
+* Added favicon link in `docs/index.html`.
+* Inserted `ico.png` within header/footer `.mark` and styled `.mark img`.
+* Updated `docs/day.html`, `docs/week.html`, and `docs/demo/index.html` to use shared favicon.
+* Next: run tests and commit.
+
+## Results
+* Header/footer brand now show `ico.png` inside themed box.
+* All marketing pages reference `ico.png` as favicon.
+* `dotnet test` passes.
+* Confidence: 0.86.

--- a/docs/day.html
+++ b/docs/day.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>Day Detail</title>
+  <!-- Use the shared planner icon for browser tab -->
+  <link rel="icon" type="image/png" href="../images/ico.png"/>
   <style>
     body { font-family: sans-serif; margin: 0; }
     .timeline { padding: 1rem; }

--- a/docs/demo/index.html
+++ b/docs/demo/index.html
@@ -1,7 +1,7 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
 <meta name="theme-color" content="#0b0c10" />
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%23111319'/%3E%3Cpath d='M18 36h28M18 24h20' stroke='%237aa2ff' stroke-width='4' stroke-linecap='round'/%3E%3C/svg%3E" />
+<link rel="icon" type="image/png" href="../../images/ico.png"/>
 <link rel="stylesheet" href="../demo.css" />
 <title>Homeschool Planner — Demos</title>
 </head><body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,8 @@
   <title>Scholar’s Forge Planner — Homeschool, Your Way</title>
   <meta name="description" content="Plan from books, time, or custom activities. Skip → Catch-up or Do Extra with a tap. Track progress and export clean reports—homeschool, your way."/>
   <meta name="theme-color" content="#f9f6f3"/>
+  <!-- Favicon: reused in header/footer brand mark -->
+  <link rel="icon" type="image/png" href="../images/ico.png"/>
 
   <style>
     /* ========= THEME TOKENS =========
@@ -117,6 +119,8 @@
     .mark{width:40px;height:40px;border-radius:12px;
       background:linear-gradient(135deg,var(--brand),var(--brand-2));
       box-shadow:var(--shadow)}
+    /* Display the icon inside the colored mark without distorting */
+    .mark img{width:100%;height:100%;object-fit:contain;padding:4px;border-radius:inherit;display:block}
     .links{display:flex;align-items:center;gap:1.2rem}
     .btn{display:inline-flex;align-items:center;justify-content:center;padding:1rem 1.2rem;border-radius:14px;border:1px solid var(--border);font-weight:800}
     .btn.ghost{background:transparent}
@@ -164,7 +168,7 @@
   <header>
     <div class="container nav" role="navigation" aria-label="Primary">
       <a class="brand" href="/" aria-label="Scholar’s Forge Planner">
-        <span class="mark" aria-hidden="true"></span>
+        <span class="mark" aria-hidden="true"><img src="../images/ico.png" alt=""/></span>
         <span>Scholar’s Forge Planner</span>
       </a>
       <div class="links">
@@ -269,7 +273,7 @@
   <!-- FOOTER -->
   <footer>
     <div class="container foot">
-      <div class="brand"><span class="mark" aria-hidden="true"></span><span>Scholar’s Forge Planner</span></div>
+      <div class="brand"><span class="mark" aria-hidden="true"><img src="../images/ico.png" alt=""/></span><span>Scholar’s Forge Planner</span></div>
       <div>
         <a href="#how">How it works</a><span class="sep"> • </span>
         <a href="#features">Features</a><span class="sep"> • </span>

--- a/docs/week.html
+++ b/docs/week.html
@@ -1,7 +1,7 @@
 <!doctype html><html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
 <meta name="theme-color" content="#0b0c10" />
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%23111319'/%3E%3Cpath d='M18 36h28M18 24h20' stroke='%237aa2ff' stroke-width='4' stroke-linecap='round'/%3E%3C/svg%3E" />
+<link rel="icon" type="image/png" href="../images/ico.png"/>
 <link rel="stylesheet" href="demo.css" />
 <title>Week Preview — Homeschool Planner</title>
 </head><body>


### PR DESCRIPTION
## Summary
- display ico.png in header/footer branding box on landing page
- reuse ico.png as favicon for landing and demo pages

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c08e7b82f4832ea950ec6cfb51f1db