### PR TITLE
feat: add OS-aware theme toggle

### DIFF
--- a/AgentNotes/2025-09-08T01-46-54Z-marketing-refresh.md
+++ b/AgentNotes/2025-09-08T01-46-54Z-marketing-refresh.md
@@ -27,3 +27,11 @@ Refine the marketing home page per client: more whitespace, real carousel, light
 * Theme preference stored in localStorage; persisted across sessions.
 * Ran `dotnet build` and `dotnet test` successfully.
 * Confidence: 0.87
+## Follow-up (2025-09-09 21:15 UTC)
+* Implement OS-based Scholar/Forge auto-selection with live follow if user hasn't chosen.
+* Add persistence script and CTA color tokens for marketing and docs.
+## Results (2025-09-09 21:18 UTC)
+* Added OS-aware Scholar/Forge theme detection with live follow until user picks and persistence across marketing and docs.
+* Introduced segmented mode switch and --ctaText token for per-theme CTA color.
+* Ran `dotnet build` and `dotnet test` successfully.
+* Confidence: 0.89

--- a/HomeschoolPlanner.Api/wwwroot/marketing/index.html
+++ b/HomeschoolPlanner.Api/wwwroot/marketing/index.html
@@ -4,6 +4,43 @@
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <title>Homeschool Planner</title>
+  <script>
+/* Scholar/Forge first-visit default + live-follow if no user choice */
+(function () {
+  var KEY = 'sf_theme';              // persisted user choice, if any
+  var root = document.documentElement;
+  var saved = null;
+
+  try { saved = localStorage.getItem(KEY); } catch(_) {}
+
+  // Decide initial mode
+  var mode = saved;
+  if (!mode) {
+    // If the browser reports a preference, map dark→forge, light→scholar
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      mode = 'forge';
+    } else {
+      // Unknown/unsupported ⇒ default to Scholar (light)
+      mode = 'scholar';
+    }
+  }
+
+  root.setAttribute('data-theme', mode);
+
+  // If the user hasn't chosen yet, reflect OS changes live
+  if (!saved && window.matchMedia) {
+    var mql = window.matchMedia('(prefers-color-scheme: dark)');
+    var onChange = function (e) {
+      // Only follow if the user still hasn't picked a theme
+      try { if (!localStorage.getItem(KEY)) {
+        root.setAttribute('data-theme', e.matches ? 'forge' : 'scholar');
+      }} catch(_) {}
+    };
+    if (mql.addEventListener) mql.addEventListener('change', onChange);
+    else if (mql.addListener) mql.addListener(onChange); // Safari/legacy
+  }
+})();
+  </script>
   <link rel="stylesheet" href="landing.css"/>
 </head>
 <body>
@@ -14,7 +51,10 @@
     <nav>
       <a href="#how">How it works</a>
       <a href="/demo">Demo</a>
-      <button id="theme-toggle" class="btn ghost" aria-label="Toggle theme">☀︎ / ☾</button>
+      <div class="mode-switch" role="tablist" aria-label="Theme mode">
+        <button id="mode-scholar" role="tab" aria-selected="true">Scholar</button>
+        <button id="mode-forge" role="tab" aria-selected="false">Forge</button>
+      </div>
     </nav>
   </div>
 </header>
@@ -62,5 +102,33 @@
 <footer class="footer">© <span id="year"></span> Homeschool Planner</footer>
 <script src="landing.js"></script>
 <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+<script>
+/* Segmented “Scholar / Forge” toggle → persist user choice */
+(function () {
+  var KEY = 'sf_theme';
+  var root = document.documentElement;
+  var bScholar = document.getElementById('mode-scholar');
+  var bForge   = document.getElementById('mode-forge');
+
+  function setMode(mode, persist) {
+    root.setAttribute('data-theme', mode);
+    if (persist) {
+      try { localStorage.setItem(KEY, mode); } catch(_) {}
+    }
+    if (bScholar && bForge) {
+      bScholar.classList.toggle('active', mode === 'scholar');
+      bForge.classList.toggle('active',   mode === 'forge');
+      bScholar.setAttribute('aria-selected', mode === 'scholar');
+      bForge.setAttribute('aria-selected',   mode === 'forge');
+    }
+  }
+
+  if (bScholar) bScholar.addEventListener('click', function(){ setMode('scholar', true); });
+  if (bForge)   bForge.addEventListener('click',   function(){ setMode('forge',   true); });
+
+  // Ensure the segmented control reflects whatever the head script chose
+  setMode(root.getAttribute('data-theme') || 'scholar', false);
+})();
+</script>
 </body>
 </html>

--- a/HomeschoolPlanner.Api/wwwroot/marketing/landing.css
+++ b/HomeschoolPlanner.Api/wwwroot/marketing/landing.css
@@ -1,5 +1,5 @@
 /* ========== Theme tokens ========== */
-:root[data-theme="light"]{
+:root[data-theme="scholar"]{
   --bg:#f6f7fb;            /* paper */
   --panel:#ffffff;         /* card */
   --soft:#f2f4f8;          /* soft panel */
@@ -7,13 +7,14 @@
   --muted:#5a6676;         /* secondary */
   --brand:#3a80ff;         /* ink blue */
   --brand-2:#5ab99b;       /* sage/teal accent */
+  --ctaText:#fff;
   --border:#dde3ee;
   --shadow:0 10px 26px rgba(10,20,40,.08);
   --radius:18px;
   --maxw:1120px; --gutter:22px;
 }
 
-:root[data-theme="dark"]{
+:root[data-theme="forge"]{
   --bg:#0e0f12;
   --panel:#14161b;
   --soft:#1b1e25;
@@ -21,6 +22,7 @@
   --muted:#b9c0d4;
   --brand:#64b5f6;
   --brand-2:#81c784;
+  --ctaText:#000;
   --border:#222736;
   --shadow:0 10px 30px rgba(0,0,0,.35);
   --radius:18px;
@@ -40,8 +42,11 @@ header{position:sticky;top:0;z-index:10;background:rgba(14,15,18,.6);backdrop-fi
 .logo{display:flex;align-items:center;gap:.6rem;font-weight:800;letter-spacing:.2px}
 .logo-mark{width:34px;height:34px;border-radius:10px;background:linear-gradient(135deg,var(--brand),var(--brand-2));box-shadow:var(--shadow)}
 .nav a{margin:0 .75rem;color:var(--muted)}
+.mode-switch{display:inline-flex;gap:0;padding:2px;border:1px solid var(--border);border-radius:12px;}
+.mode-switch button{all:unset;cursor:pointer;padding:.5rem .8rem;min-width:80px;text-align:center;border-radius:10px;font-weight:800;color:var(--fg);}
+.mode-switch button.active{background:var(--brand);color:var(--ctaText);}
 .btn{display:inline-flex;align-items:center;justify-content:center;padding:.85rem 1.1rem;border-radius:12px;border:1px solid #2a3244;font-weight:800}
-.btn.primary{background:linear-gradient(180deg,#7aa2ff,#547dff);color:#0b1533;border-color:#688fff}
+.btn.primary{background:linear-gradient(180deg,#7aa2ff,#547dff);color:var(--ctaText);border-color:#688fff}
 .btn.ghost{background:transparent;color:var(--fg)}
 /* Hero */
 section{padding:72px 0;border-top:1px solid #1a1f2b}

--- a/HomeschoolPlanner.Api/wwwroot/marketing/landing.js
+++ b/HomeschoolPlanner.Api/wwwroot/marketing/landing.js
@@ -3,19 +3,3 @@ const slides=[...document.querySelectorAll('.slide')];
 const dots  =[...document.querySelectorAll('.dot')];
 let i=0; function show(n){slides.forEach((s,k)=>s.classList.toggle('active',k===n));dots.forEach((d,k)=>d.classList.toggle('active',k===n));}
 if(slides.length){ show(0); setInterval(()=>{ i=(i+1)%slides.length; show(i); }, 4000); }
-
-// ---- Theme toggle with persistence ----
-(function(){
-  const key = 'hs_theme';
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const current = localStorage.getItem(key) || (prefersDark ? 'dark' : 'light');
-  document.documentElement.setAttribute('data-theme', current);
-  const btn = document.getElementById('theme-toggle');
-  if(btn){
-    btn.addEventListener('click', ()=>{
-      const next = (document.documentElement.getAttribute('data-theme') === 'dark') ? 'light' : 'dark';
-      document.documentElement.setAttribute('data-theme', next);
-      localStorage.setItem(key, next);
-    });
-  }
-})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,6 +9,44 @@
   <!-- Favicon: reused in header/footer brand mark -->
   <link rel="icon" type="image/png" href="images/ico.png"/>
 
+  <script>
+/* Scholar/Forge first-visit default + live-follow if no user choice */
+(function () {
+  var KEY = 'sf_theme';              // persisted user choice, if any
+  var root = document.documentElement;
+  var saved = null;
+
+  try { saved = localStorage.getItem(KEY); } catch(_) {}
+
+  // Decide initial mode
+  var mode = saved;
+  if (!mode) {
+    // If the browser reports a preference, map dark→forge, light→scholar
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      mode = 'forge';
+    } else {
+      // Unknown/unsupported ⇒ default to Scholar (light)
+      mode = 'scholar';
+    }
+  }
+
+  root.setAttribute('data-theme', mode);
+
+  // If the user hasn't chosen yet, reflect OS changes live
+  if (!saved && window.matchMedia) {
+    var mql = window.matchMedia('(prefers-color-scheme: dark)');
+    var onChange = function (e) {
+      // Only follow if the user still hasn't picked a theme
+      try { if (!localStorage.getItem(KEY)) {
+        root.setAttribute('data-theme', e.matches ? 'forge' : 'scholar');
+      }} catch(_) {}
+    };
+    if (mql.addEventListener) mql.addEventListener('change', onChange);
+    else if (mql.addListener) mql.addListener(onChange); // Safari/legacy
+  }
+})();
+  </script>
+
   <style>
     /* ========= THEME TOKENS =========
        Scholar  = Light (sky blue + soft purple)
@@ -49,6 +87,7 @@
       --border:#e7e1dc;
       --shadow:0 14px 40px rgba(22,16,9,.08);
       --radius:20px; --gutter:28px; --maxw:1200px;
+      --ctaText:#fff;
     }
     :root[data-theme="forge"]{
       --bg:#0e0f12;
@@ -63,6 +102,7 @@
       --border:#222736;
       --shadow:0 18px 46px rgba(0,0,0,.35);
       --radius:20px; --gutter:28px; --maxw:1200px;
+      --ctaText:#000;
     }
     /* Hero bullet list (replaces dotted squircles) */
     .hero-bullets{margin:0; padding:0; list-style:none; display:grid; gap:12px}
@@ -79,13 +119,8 @@
     .btn.primary{
       background:linear-gradient(180deg,var(--brand),var(--brand-2));
       border:1px solid color-mix(in oklab, var(--brand) 65%, var(--brand-2));
-      color:rgba(0, 0, 0, 1);
+      color:var(--ctaText);
     }
-    /* Scholar = light → white text */
-    :root[data-theme="scholar"] .btn.primary { color:#fff; }
-
-    /* Forge = dark → black text */
-    :root[data-theme="forge"] .btn.primary { color:#000; }
 
     /* Global spacing nudge */
     section{padding:110px 0}        /* was ~96px */
@@ -293,42 +328,35 @@
     </div>
   </footer>
 
-  <!-- MODE + CAROUSEL scripts -->
+  <script src="landing.js"></script>
+  <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
   <script>
+/* Segmented “Scholar / Forge” toggle → persist user choice */
+(function () {
+  var KEY = 'sf_theme';
+  var root = document.documentElement;
+  var bScholar = document.getElementById('mode-scholar');
+  var bForge   = document.getElementById('mode-forge');
 
-    (function(){
-      const KEY='sf_theme';
-      const prefersDark = matchMedia('(prefers-color-scheme: dark)').matches;
-      const initial = localStorage.getItem(KEY) || (prefersDark?'forge':'scholar');
-      const root = document.documentElement;
-      const bScholar = document.getElementById('mode-scholar');
-      const bForge   = document.getElementById('mode-forge');
+  function setMode(mode, persist) {
+    root.setAttribute('data-theme', mode);
+    if (persist) {
+      try { localStorage.setItem(KEY, mode); } catch(_) {}
+    }
+    if (bScholar && bForge) {
+      bScholar.classList.toggle('active', mode === 'scholar');
+      bForge.classList.toggle('active',   mode === 'forge');
+      bScholar.setAttribute('aria-selected', mode === 'scholar');
+      bForge.setAttribute('aria-selected',   mode === 'forge');
+    }
+  }
 
-      function setMode(mode){
-        root.setAttribute('data-theme', mode);
-        localStorage.setItem(KEY, mode);
-        // ARIA + visual state
-        bScholar.classList.toggle('active', mode==='scholar');
-        bForge.classList.toggle('active', mode==='forge');
-        bScholar.setAttribute('aria-selected', mode==='scholar');
-        bForge.setAttribute('aria-selected', mode==='forge');
-        bScholar.dataset.mode='scholar'; bForge.dataset.mode='forge';
-      }
+  if (bScholar) bScholar.addEventListener('click', function(){ setMode('scholar', true); });
+  if (bForge)   bForge.addEventListener('click',   function(){ setMode('forge',   true); });
 
-      setMode(initial);
-      bScholar.addEventListener('click', ()=> setMode('scholar'));
-      bForge.addEventListener('click',   ()=> setMode('forge'));
-    })();
-
-    // Simple auto-rotating carousel
-    (function(){
-      const slides=[...document.querySelectorAll('.slide')];
-      const dots=[...document.querySelectorAll('.dot')];
-      let i=0; function show(n){slides.forEach((s,k)=>s.classList.toggle('active',k===n));
-                                dots.forEach((d,k)=>d.classList.toggle('active',k===n));}
-      if(slides.length){ show(0); setInterval(()=>{ i=(i+1)%slides.length; show(i); }, 4400); }
-      document.getElementById('year').textContent=new Date().getFullYear();
-    })();
+  // Ensure the segmented control reflects whatever the head script chose
+  setMode(root.getAttribute('data-theme') || 'scholar', false);
+})();
   </script>
 </body>
 </html>

--- a/docs/landing.css
+++ b/docs/landing.css
@@ -1,5 +1,5 @@
-/* Theme tokens: warm light/dark (non-pink) */
-:root[data-theme="light"]{
+/* Theme tokens: warm Scholar/Forge (non-pink) */
+:root[data-theme="scholar"]{
   --bg:#f9f6f3;          /* warm paper */
   --panel:#ffffff;       /* cards */
   --soft:#fff6ef;        /* soft peach tint for hero blocks */
@@ -7,11 +7,12 @@
   --muted:#697585;       /* secondary */
   --brand:#3a80ff;       /* ink blue */
   --accent:#5ab99b;      /* sage */
+  --ctaText:#fff;
   --border:#e7e1dc;
   --shadow:0 12px 36px rgba(22,16,9,.06);
   --radius:18px; --maxw:1120px; --gutter:24px;
 }
-:root[data-theme="dark"]{
+:root[data-theme="forge"]{
   --bg:#0e0f12;
   --panel:#14161b;
   --soft:#1b1e25;
@@ -19,6 +20,7 @@
   --muted:#b9c0d4;
   --brand:#64b5f6;
   --accent:#81c784;
+  --ctaText:#000;
   --border:#222736;
   --shadow:0 12px 36px rgba(0,0,0,.35);
   --radius:18px; --maxw:1120px; --gutter:24px;
@@ -33,6 +35,9 @@ color:var(--fg);font:16px/1.6 ui-sans-serif,system-ui,-apple-system,Segoe UI,Rob
 a{color:var(--brand);text-decoration:none}
 a:hover{opacity:.9}
 .container{max-width:var(--maxw);margin:0 auto;padding:0 var(--gutter)}
+.mode-switch{display:inline-flex;gap:0;padding:2px;border:1px solid var(--border);border-radius:12px;}
+.mode-switch button{all:unset;cursor:pointer;padding:.5rem .8rem;min-width:80px;text-align:center;border-radius:10px;font-weight:800;color:var(--fg);}
+.mode-switch button.active{background:var(--brand);color:var(--ctaText);}
 header{position:sticky;top:0;z-index:10;background:rgba(255,255,255,.6);backdrop-filter:blur(8px);
   border-bottom:1px solid var(--border)}
 @media (prefers-color-scheme: dark){
@@ -40,6 +45,6 @@ header{position:sticky;top:0;z-index:10;background:rgba(255,255,255,.6);backdrop
 }
 .hero-card,.card{background:linear-gradient(180deg,var(--panel),var(--soft));border:1px solid var(--border);border-radius:var(--radius);box-shadow:var(--shadow)}
 .pill{padding:.55rem .8rem;border:1px dashed #d7d1cc;border-radius:999px;background:#fffdfb}
-.btn.primary{background:linear-gradient(180deg,#7aa2ff,#547dff);color:#0b1533;border:1px solid #688fff;border-radius:12px;padding:.9rem 1.1rem;font-weight:800}
+.btn.primary{background:linear-gradient(180deg,#7aa2ff,#547dff);color:var(--ctaText);border:1px solid #688fff;border-radius:12px;padding:.9rem 1.1rem;font-weight:800}
 .btn.ghost{border:1px solid var(--border);border-radius:12px;padding:.9rem 1.1rem}
 .carousel .slide{min-height:340px}

--- a/docs/landing.js
+++ b/docs/landing.js
@@ -3,19 +3,3 @@ const slides=[...document.querySelectorAll('.slide')];
 const dots  =[...document.querySelectorAll('.dot')];
 let i=0; function show(n){slides.forEach((s,k)=>s.classList.toggle('active',k===n));dots.forEach((d,k)=>d.classList.toggle('active',k===n));}
 if(slides.length){ show(0); setInterval(()=>{ i=(i+1)%slides.length; show(i); }, 4000); }
-
-// ---- Theme toggle with persistence ----
-(function(){
-  const key = 'hs_theme';
-  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const current = localStorage.getItem(key) || (prefersDark ? 'dark' : 'light');
-  document.documentElement.setAttribute('data-theme', current);
-  const btn = document.getElementById('theme-toggle');
-  if(btn){
-    btn.addEventListener('click', ()=>{
-      const next = (document.documentElement.getAttribute('data-theme') === 'dark') ? 'light' : 'dark';
-      document.documentElement.setAttribute('data-theme', next);
-      localStorage.setItem(key, next);
-    });
-  }
-})();


### PR DESCRIPTION
## Summary
- default Scholar/Forge theme to the OS preference on first load and follow OS changes until the user picks
- persist user-selected theme via segmented control and new `--ctaText` token
- mirror scripts and styles for docs landing copy

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c0983cbcd0832ebf2f79c9bc795b06