### PR TITLE
style: add mobile responsive patch to landing

### DIFF
--- a/AgentNotes/2025-09-08T01-46-54Z-marketing-refresh.md
+++ b/AgentNotes/2025-09-08T01-46-54Z-marketing-refresh.md
@@ -35,3 +35,10 @@ Refine the marketing home page per client: more whitespace, real carousel, light
 * Introduced segmented mode switch and --ctaText token for per-theme CTA color.
 * Ran `dotnet build` and `dotnet test` successfully.
 * Confidence: 0.89
+## Follow-up (2025-09-09 21:56 UTC)
+* Apply mobile responsive patch to landing page CSS in marketing and docs.
+* Ensure patch covers hero, carousel, buttons, grids per provided snippet and run dotnet build/test after changes.
+## Results (2025-09-09 21:57 UTC)
+* Added mobile responsive CSS patch to landing pages under marketing and docs to improve small-screen layout.
+* Attempted `dotnet build` and `dotnet test` but `dotnet` SDK is unavailable in environment.
+* Confidence: 0.84

--- a/HomeschoolPlanner.Api/wwwroot/marketing/landing.css
+++ b/HomeschoolPlanner.Api/wwwroot/marketing/landing.css
@@ -72,3 +72,43 @@ h1{font-size:clamp(2.2rem,4vw,3.2rem);line-height:1.1;margin:.2rem 0 1rem}
 @media(max-width:960px){.grid-3,.grid-2{grid-template-columns:1fr}}
 .muted{color:var(--muted)}
 .footer{padding:36px 0;color:#9aa4bf;text-align:center}
+/* ========== MOBILE RESPONSIVE PATCH ========== */
+
+/* Small phones (≤ 600px) */
+@media (max-width: 600px){
+
+  /* Give the page some breathing room on narrow viewports */
+  .container{padding:0 18px}
+
+  /* Hero becomes one column; tighten vertical rhythm */
+  .hero{grid-template-columns:1fr; gap:24px}
+  h1{font-size:clamp(1.8rem, 8vw, 2.4rem); margin-bottom:18px}
+  .lead{font-size:1rem; margin-bottom:14px}
+
+  /* Hero bullets as a single vertical list, not two-up */
+  .hero-bullets{display:grid; grid-template-columns:1fr; gap:10px}
+  .hero-card{padding:18px}
+
+  /* CTA buttons: full width, stacked */
+  .btn-row, .pills{gap:.6rem}
+  .btn-row{flex-direction:column; align-items:stretch}
+  .btn-row .btn{width:100%}
+
+  /* Carousel: use aspect-ratio instead of a fixed min-height */
+  .carousel{border-radius:16px}
+  .slide{min-height:auto; aspect-ratio: 16 / 9; background-size:cover; background-position:center}
+
+  /* Feature/pain grids collapse to one column */
+  .grid-2{grid-template-columns:1fr; gap:18px}
+  .grid-3{grid-template-columns:1fr; gap:18px}
+
+  /* Cards a touch tighter on phones */
+  .card{padding:18px}
+}
+
+/* Tight phones (≤ 360px) – small type/spacing safety net */
+@media (max-width: 360px){
+  h1{font-size:clamp(1.6rem, 8.8vw, 2.2rem)}
+  .lead{font-size:.95rem}
+  .btn{padding:.9rem 1rem; border-radius:12px}
+}

--- a/docs/landing.css
+++ b/docs/landing.css
@@ -48,3 +48,43 @@ header{position:sticky;top:0;z-index:10;background:rgba(255,255,255,.6);backdrop
 .btn.primary{background:linear-gradient(180deg,#7aa2ff,#547dff);color:var(--ctaText);border:1px solid #688fff;border-radius:12px;padding:.9rem 1.1rem;font-weight:800}
 .btn.ghost{border:1px solid var(--border);border-radius:12px;padding:.9rem 1.1rem}
 .carousel .slide{min-height:340px}
+/* ========== MOBILE RESPONSIVE PATCH ========== */
+
+/* Small phones (≤ 600px) */
+@media (max-width: 600px){
+
+  /* Give the page some breathing room on narrow viewports */
+  .container{padding:0 18px}
+
+  /* Hero becomes one column; tighten vertical rhythm */
+  .hero{grid-template-columns:1fr; gap:24px}
+  h1{font-size:clamp(1.8rem, 8vw, 2.4rem); margin-bottom:18px}
+  .lead{font-size:1rem; margin-bottom:14px}
+
+  /* Hero bullets as a single vertical list, not two-up */
+  .hero-bullets{display:grid; grid-template-columns:1fr; gap:10px}
+  .hero-card{padding:18px}
+
+  /* CTA buttons: full width, stacked */
+  .btn-row, .pills{gap:.6rem}
+  .btn-row{flex-direction:column; align-items:stretch}
+  .btn-row .btn{width:100%}
+
+  /* Carousel: use aspect-ratio instead of a fixed min-height */
+  .carousel{border-radius:16px}
+  .slide{min-height:auto; aspect-ratio: 16 / 9; background-size:cover; background-position:center}
+
+  /* Feature/pain grids collapse to one column */
+  .grid-2{grid-template-columns:1fr; gap:18px}
+  .grid-3{grid-template-columns:1fr; gap:18px}
+
+  /* Cards a touch tighter on phones */
+  .card{padding:18px}
+}
+
+/* Tight phones (≤ 360px) – small type/spacing safety net */
+@media (max-width: 360px){
+  h1{font-size:clamp(1.6rem, 8.8vw, 2.2rem)}
+  .lead{font-size:.95rem}
+  .btn{padding:.9rem 1rem; border-radius:12px}
+}


### PR DESCRIPTION
## Summary
- add mobile responsive CSS patch for landing pages in marketing and docs
- document attempt and results in AgentNotes

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a25b7ce0832e9857271425192f91