### PR TITLE
Add beta sign-up and about-us sections to marketing pages

### DIFF
--- a/AgentNotes/2025-09-08T01-46-54Z-marketing-refresh.md
+++ b/AgentNotes/2025-09-08T01-46-54Z-marketing-refresh.md
@@ -42,3 +42,15 @@ Refine the marketing home page per client: more whitespace, real carousel, light
 * Added mobile responsive CSS patch to landing pages under marketing and docs to improve small-screen layout.
 * Attempted `dotnet build` and `dotnet test` but `dotnet` SDK is unavailable in environment.
 * Confidence: 0.84
+
+## Follow-up (2025-09-10 00:00 UTC)
+* Add "Beta testers" and "About us" sections above pricing in marketing landing page (docs & marketing).
+* Include email input/button and bullet expectations card; add About Us with founder and contact info.
+
+
+## Results (2025-09-10 00:15 UTC)
+* Inserted beta sign-up and about-us sections on landing pages in docs and marketing.
+* Added form styles in landing CSS.
+* Build and tests succeed with .NET 9 SDK.
+* Confidence: 0.85
+

--- a/HomeschoolPlanner.Api/wwwroot/marketing/index.html
+++ b/HomeschoolPlanner.Api/wwwroot/marketing/index.html
@@ -99,6 +99,44 @@
   </div>
 </section>
 
+<!-- Beta testers -->
+<section class="container" id="beta" aria-labelledby="beta-title">
+  <div class="grid-2">
+    <div>
+      <h2 id="beta-title">Beta testers wanted for December</h2>
+      <p class="muted">We&rsquo;re targeting December for testing. Join the list to try Scholar&rsquo;s Forge Planner. Share what you love and what you don&rsquo;t, and shape the roadmap.</p>
+      <form class="beta-form" aria-label="Beta sign-up">
+        <input type="email" placeholder="you@example.com" required />
+        <button class="btn primary" type="submit">Add me to the beta</button>
+      </form>
+      <p class="muted" style="margin-top:8px">Prefer email? <a href="mailto:hello@scholarsforge.app">hello@scholarsforge.app</a></p>
+    </div>
+    <div class="card">
+      <h3>What we&rsquo;ll ask from you</h3>
+      <ul class="muted">
+        <li>Use the planner with real learners for a couple of weeks.</li>
+        <li>Send feedback on planning, rescheduling, and reports.</li>
+        <li>Tell us what to improve or add next.</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- About us -->
+<section class="container" id="about" aria-labelledby="about-title">
+  <h2 id="about-title">About us</h2>
+  <div class="grid-2">
+    <div class="card">
+      <p><strong>Founded by a former homeschooling mom of four</strong>, Scholar&rsquo;s Forge is built with a deep respect for family‑first education. We&rsquo;ve taught, tested, and iterated, so you can stay focused on your kids.</p>
+    </div>
+    <div class="card">
+      <h3>Contact us</h3>
+      <p class="muted">Conference organizers, co-ops, and partners, we&rsquo;d love to connect. Speaking opportunities welcome.</p>
+      <p><a href="mailto:hello@scholarsforge.app">hello@scholarsforge.app</a></p>
+    </div>
+  </div>
+</section>
+
 <footer class="footer">© <span id="year"></span> Homeschool Planner</footer>
 <script src="landing.js"></script>
 <script>document.getElementById('year').textContent=new Date().getFullYear();</script>

--- a/HomeschoolPlanner.Api/wwwroot/marketing/landing.css
+++ b/HomeschoolPlanner.Api/wwwroot/marketing/landing.css
@@ -65,6 +65,9 @@ h1{font-size:clamp(2.2rem,4vw,3.2rem);line-height:1.1;margin:.2rem 0 1rem}
 .dots{display:flex;gap:.5rem;justify-content:center;padding:.6rem .8rem}
 .dot{width:8px;height:8px;border-radius:50%;background:#2a3344;border:1px solid var(--border)}
 .dot.active{background:#7aa2ff}
+/* Beta sign-up form */
+.beta-form{display:flex;gap:.6rem;margin-top:1rem}
+.beta-form input{flex:1;padding:.8rem 1rem;border:1px solid var(--border);border-radius:12px;font-size:1rem}
 /* Feature grids */
 .card{background:linear-gradient(180deg,var(--panel),var(--soft));border:1px solid var(--border);border-radius:var(--radius);padding:20px;box-shadow:var(--shadow)}
 .grid-3{display:grid;grid-template-columns:repeat(3,1fr);gap:18px}

--- a/docs/index.html
+++ b/docs/index.html
@@ -300,6 +300,50 @@
       <br>
     </section>
 
+    <!-- BETA TESTERS -->
+    <section class="container" id="beta" aria-labelledby="beta-title">
+      <br>
+      <div class="grid-2">
+        <div>
+          <h2 id="beta-title">Beta testers wanted for December</h2>
+          <p class="muted">We&rsquo;re targeting December for testing. Join the list to try Scholar&rsquo;s Forge Planner. Share what you love and what you don&rsquo;t, and shape the roadmap.</p>
+          <form class="beta-form" aria-label="Beta sign-up">
+            <input type="email" placeholder="you@example.com" required />
+            <button class="btn primary" type="submit">Add me to the beta</button>
+          </form>
+          <p class="muted" style="margin-top:8px">Prefer email? <a href="mailto:hello@scholarsforge.app">hello@scholarsforge.app</a></p>
+        </div>
+        <div class="card">
+          <h3>What we&rsquo;ll ask from you</h3>
+          <ul class="muted">
+            <li>Use the planner with real learners for a couple of weeks.</li>
+            <li>Send feedback on planning, rescheduling, and reports.</li>
+            <li>Tell us what to improve or add next.</li>
+          </ul>
+        </div>
+      </div>
+      <br>
+      <br>
+    </section>
+
+    <!-- ABOUT US -->
+    <section class="container" id="about" aria-labelledby="about-title">
+      <br>
+      <h2 id="about-title">About us</h2>
+      <div class="grid-2">
+        <div class="card">
+          <p><strong>Founded by a former homeschooling mom of four</strong>, Scholar&rsquo;s Forge is built with a deep respect for family‑first education. We&rsquo;ve taught, tested, and iterated, so you can stay focused on your kids.</p>
+        </div>
+        <div class="card">
+          <h3>Contact us</h3>
+          <p class="muted">Conference organizers, co-ops, and partners, we&rsquo;d love to connect. Speaking opportunities welcome.</p>
+          <p><a href="mailto:hello@scholarsforge.app">hello@scholarsforge.app</a></p>
+        </div>
+      </div>
+      <br>
+      <br>
+    </section>
+
     <!-- PRICING (placeholder) -->
     <section class="container" id="pricing" aria-labelledby="pricing-title">
       <br>

--- a/docs/landing.css
+++ b/docs/landing.css
@@ -48,6 +48,9 @@ header{position:sticky;top:0;z-index:10;background:rgba(255,255,255,.6);backdrop
 .btn.primary{background:linear-gradient(180deg,#7aa2ff,#547dff);color:var(--ctaText);border:1px solid #688fff;border-radius:12px;padding:.9rem 1.1rem;font-weight:800}
 .btn.ghost{border:1px solid var(--border);border-radius:12px;padding:.9rem 1.1rem}
 .carousel .slide{min-height:340px}
+.beta-form{display:flex;gap:.6rem;margin-top:1rem}
+.beta-form input{flex:1;padding:.8rem 1rem;border:1px solid var(--border);border-radius:12px;font-size:1rem}
+
 /* ========== MOBILE RESPONSIVE PATCH ========== */
 
 /* Small phones (≤ 600px) */


### PR DESCRIPTION
## Summary
- add beta testers call-to-action with email signup and expectations card
- include about-us block with founder details and contact info
- style beta form and mirror changes to API marketing copy

## Testing
- `~/.dotnet/dotnet build`
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c17d9a072c832ebec881b1b5c7ada5