### PR TITLE
chore: link mobile preview buttons to week demo

### DIFF
--- a/AgentNotes/2025-09-10T13-50-43Z-mobile-preview-link.md
+++ b/AgentNotes/2025-09-10T13-50-43Z-mobile-preview-link.md
@@ -1,0 +1,17 @@
+## Task
+We need to hook up the button for C-Mobile Preview and try the today week preview to hook up to the week.html. That page needs to be hooked up so we can start working on it.
+
+## Initial considerations
+- Landing page buttons should point directly to the Week Preview demo for quicker access.
+- Update both the docs and marketing copies.
+- Run `dotnet test` after changes.
+
+## Follow-up (2025-09-10 14:00 UTC)
+- Updated docs and marketing landing pages to point buttons directly to Week Preview demo.
+- Added inline comments explaining new links.
+- Next: run `dotnet test`.
+
+## Results
+- Buttons route directly to Week Preview demo.
+- `dotnet test` passed (4 tests).
+- Confidence: 0.9

--- a/HomeschoolPlanner.Api/wwwroot/marketing/index.html
+++ b/HomeschoolPlanner.Api/wwwroot/marketing/index.html
@@ -72,7 +72,8 @@
         <span class="pill">Progress by subject</span>
       </div>
       <div class="row">
-        <a class="btn primary" href="/demo">See mobile preview</a>
+        <!-- Direct link to Week Preview demo -->
+        <a class="btn primary" href="/demo/week.html">See mobile preview</a>
         <a class="btn ghost" href="#how">How it works</a>
       </div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -215,7 +215,8 @@
           <button id="mode-scholar" role="tab" aria-selected="true">Scholar</button>
           <button id="mode-forge" role="tab" aria-selected="false">Forge</button>
         </div>
-        <a class="btn primary" href="/demo">See mobile preview</a>
+        <!-- Direct link to Week Preview demo -->
+        <a class="btn primary" href="/week.html">See mobile preview</a>
       </div>
     </div>
   </header>
@@ -239,7 +240,8 @@
             <li><strong>Clear progress</strong> by subject</li>
           </ul>
           <div class="pills" style="margin-top:1rem">
-            <a class="btn primary" href="/demo">Try the Today/Week preview</a>
+            <!-- Jump straight to Week Preview for quick testing -->
+            <a class="btn primary" href="/week.html">Try the Today/Week preview</a>
             <a class="btn" href="#how">How it works</a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- point marketing "See mobile preview" and "Today/Week" buttons straight to Week Preview
- same update mirrored in API's marketing copy

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68c1816954e8832ea0423dace490b3e7