### PR TITLE
Fix mobile preview link path

### DIFF
--- a/AgentNotes/2025-09-10T13-50-43Z-mobile-preview-link.md
+++ b/AgentNotes/2025-09-10T13-50-43Z-mobile-preview-link.md
@@ -11,7 +11,12 @@ We need to hook up the button for C-Mobile Preview and try the today week previe
 - Added inline comments explaining new links.
 - Next: run `dotnet test`.
 
+## Follow-up (2025-09-10 15:25 UTC)
+- Corrected header button to point to `/docs/week.html` so the preview link resolves properly.
+- Clarified intent with an inline comment.
+
 ## Results
 - Buttons route directly to Week Preview demo.
+- Header link now points to `/docs/week.html`.
 - `dotnet test` passed (4 tests).
-- Confidence: 0.9
+- Confidence: 0.95

--- a/docs/index.html
+++ b/docs/index.html
@@ -215,8 +215,8 @@
           <button id="mode-scholar" role="tab" aria-selected="true">Scholar</button>
           <button id="mode-forge" role="tab" aria-selected="false">Forge</button>
         </div>
-        <!-- Direct link to Week Preview demo -->
-        <a class="btn primary" href="/week.html">See mobile preview</a>
+        <!-- Direct link to Week Preview demo; use docs path so it resolves from root -->
+        <a class="btn primary" href="/docs/week.html">See mobile preview</a>
       </div>
     </div>
   </header>
@@ -240,8 +240,8 @@
             <li><strong>Clear progress</strong> by subject</li>
           </ul>
           <div class="pills" style="margin-top:1rem">
-            <!-- Jump straight to Week Preview for quick testing -->
-            <a class="btn primary" href="/week.html">Try the Today/Week preview</a>
+            <!-- Jump straight to Week Preview for quick testing; docs path ensures correct routing -->
+            <a class="btn primary" href="/docs/week.html">Try the Today/Week preview</a>
             <a class="btn" href="#how">How it works</a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- ensure the "See mobile preview" header button points to `/docs/week.html`
- update note for mobile preview link maintenance

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c197bcd524832ebce079accf6042ad