### PR TITLE
feat: update marketing nav links

### DIFF
--- a/AgentNotes/2025-09-10T21-46-03Z-nav-links.md
+++ b/AgentNotes/2025-09-10T21-46-03Z-nav-links.md
@@ -1,0 +1,24 @@
+## Task
+Adjust the top navigation bar buttons to Blog, About Us, and Contact Us.
+
+## Initial considerations
+* Nav changes in marketing pages under docs/ and HomeschoolPlanner.Api/wwwroot/marketing/.
+* Blog links to Blogspot homepage (external).
+* About Us will link to future about page; link stub.
+* Need Contact Us page; mirror in both docs and marketing.
+* Update header nav to only include Blog, About Us, Contact Us plus existing theme toggle.
+* Run dotnet build and test after changes.
+## Follow-up (2025-09-10 21:50 UTC)
+* Locate nav bar in docs/index.html and marketing index; plan to replace existing nav links.
+* Will remove "How it works", "Features", "Pricing", and "Demo" nav items; add Blog, About Us, Contact Us.
+* Create placeholder contact pages under docs/ and marketing/ with matching nav and footer.
+## Follow-up (2025-09-10 22:05 UTC)
+* Replaced nav links in docs/index.html and marketing index with Blog, About Us, Contact Us.
+* Removed "See mobile preview" button from nav.
+* Updated docs index footer to match new links.
+* Created mirrored contact pages under docs/contact.html and marketing/contact.html with matching header/footer and theme toggle.
+## Results
+* Updated marketing and docs navigation to Blog/About/Contact and mirrored footer.
+* Added placeholder contact pages with theme toggle and footer.
+* Installed .NET SDK via script to run builds/tests; `dotnet build` and `dotnet test` succeeded.
+* Confidence: 0.87

--- a/HomeschoolPlanner.Api/wwwroot/marketing/contact.html
+++ b/HomeschoolPlanner.Api/wwwroot/marketing/contact.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Contact Us — Homeschool Planner</title>
+  <meta name="description" content="Get in touch with the Homeschool Planner team."/>
+  <script>
+/* Scholar/Forge first-visit default + live-follow if no user choice */
+(function () {
+  var KEY = 'sf_theme';              // persisted user choice, if any
+  var root = document.documentElement;
+  var saved = null;
+
+  try { saved = localStorage.getItem(KEY); } catch(_) {}
+
+  // Decide initial mode
+  var mode = saved;
+  if (!mode) {
+    // If the browser reports a preference, map dark→forge, light→scholar
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      mode = 'forge';
+    } else {
+      // Unknown/unsupported ⇒ default to Scholar (light)
+      mode = 'scholar';
+    }
+  }
+
+  root.setAttribute('data-theme', mode);
+
+  // If the user hasn't chosen yet, reflect OS changes live
+  if (!saved && window.matchMedia) {
+    var mql = window.matchMedia('(prefers-color-scheme: dark)');
+    var onChange = function (e) {
+      // Only follow if the user still hasn't picked a theme
+      try { if (!localStorage.getItem(KEY)) {
+        root.setAttribute('data-theme', e.matches ? 'forge' : 'scholar');
+      }} catch(_) {}
+    };
+    if (mql.addEventListener) mql.addEventListener('change', onChange);
+    else if (mql.addListener) mql.addListener(onChange); // Safari/legacy
+  }
+})();
+  </script>
+  <link rel="stylesheet" href="landing.css"/>
+</head>
+<body>
+  <header>
+    <div class="container nav">
+      <a class="logo" href="/"><span class="logo-mark"></span>Homeschool Planner</a>
+      <nav>
+        <a href="https://www.blogger.com" target="_blank" rel="noopener">Blog</a>
+        <a href="about.html">About Us</a>
+        <a href="contact.html">Contact Us</a>
+        <div class="mode-switch" role="tablist" aria-label="Theme mode">
+          <button id="mode-scholar" role="tab" aria-selected="true">Scholar</button>
+          <button id="mode-forge" role="tab" aria-selected="false">Forge</button>
+        </div>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="container" id="contact" aria-labelledby="contact-title">
+      <br>
+      <h1 id="contact-title">Contact Us</h1>
+      <p class="muted">Conference organizers, co-ops, and partners, we’d love to connect. Speaking opportunities welcome.</p>
+      <p><a href="mailto:support@scholarsforge.com">support@scholarsforge.com</a></p>
+      <br>
+      <br>
+    </section>
+  </main>
+
+  <footer class="footer">© <span id="year"></span> Homeschool Planner</footer>
+
+  <script src="landing.js"></script>
+  <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+  <script>
+/* Segmented “Scholar / Forge” toggle → persist user choice */
+(function () {
+  var KEY = 'sf_theme';
+  var root = document.documentElement;
+  var bScholar = document.getElementById('mode-scholar');
+  var bForge   = document.getElementById('mode-forge');
+
+  function setMode(mode, persist) {
+    root.setAttribute('data-theme', mode);
+    if (persist) {
+      try { localStorage.setItem(KEY, mode); } catch(_) {}
+    }
+    if (bScholar && bForge) {
+      bScholar.classList.toggle('active', mode === 'scholar');
+      bForge.classList.toggle('active',   mode === 'forge');
+      bScholar.setAttribute('aria-selected', mode === 'scholar');
+      bForge.setAttribute('aria-selected',   mode === 'forge');
+    }
+  }
+
+  if (bScholar) bScholar.addEventListener('click', function(){ setMode('scholar', true); });
+  if (bForge)   bForge.addEventListener('click',   function(){ setMode('forge',   true); });
+
+  // Ensure the segmented control reflects whatever the head script chose
+  setMode(root.getAttribute('data-theme') || 'scholar', false);
+})();
+  </script>
+</body>
+</html>
+

--- a/HomeschoolPlanner.Api/wwwroot/marketing/index.html
+++ b/HomeschoolPlanner.Api/wwwroot/marketing/index.html
@@ -49,8 +49,9 @@
   <div class="container nav">
     <a class="logo" href="/"><span class="logo-mark"></span>Homeschool Planner</a>
     <nav>
-      <a href="#how">How it works</a>
-      <a href="/demo">Demo</a>
+      <a href="https://www.blogger.com" target="_blank" rel="noopener">Blog</a>
+      <a href="about.html">About Us</a>
+      <a href="contact.html">Contact Us</a>
       <div class="mode-switch" role="tablist" aria-label="Theme mode">
         <button id="mode-scholar" role="tab" aria-selected="true">Scholar</button>
         <button id="mode-forge" role="tab" aria-selected="false">Forge</button>

--- a/docs/contact.html
+++ b/docs/contact.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>Contact Us — Scholar’s Forge Planner</title>
+  <meta name="description" content="Get in touch with the Scholar’s Forge Planner team."/>
+  <meta name="theme-color" content="#f9f6f3"/>
+  <link rel="icon" type="image/png" href="images/icowbkg.png"/>
+  <link rel="stylesheet" href="landing.css"/>
+  <script>
+/* Scholar/Forge first-visit default + live-follow if no user choice */
+(function () {
+  var KEY = 'sf_theme';              // persisted user choice, if any
+  var root = document.documentElement;
+  var saved = null;
+
+  try { saved = localStorage.getItem(KEY); } catch(_) {}
+
+  // Decide initial mode
+  var mode = saved;
+  if (!mode) {
+    // If the browser reports a preference, map dark→forge, light→scholar
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      mode = 'forge';
+    } else {
+      // Unknown/unsupported ⇒ default to Scholar (light)
+      mode = 'scholar';
+    }
+  }
+
+  root.setAttribute('data-theme', mode);
+
+  // If the user hasn't chosen yet, reflect OS changes live
+  if (!saved && window.matchMedia) {
+    var mql = window.matchMedia('(prefers-color-scheme: dark)');
+    var onChange = function (e) {
+      // Only follow if the user still hasn't picked a theme
+      try { if (!localStorage.getItem(KEY)) {
+        root.setAttribute('data-theme', e.matches ? 'forge' : 'scholar');
+      }} catch(_) {}
+    };
+    if (mql.addEventListener) mql.addEventListener('change', onChange);
+    else if (mql.addListener) mql.addListener(onChange); // Safari/legacy
+  }
+})();
+  </script>
+</head>
+<body>
+  <header>
+    <div class="container nav" role="navigation" aria-label="Primary">
+      <a class="brand" href="/" aria-label="Scholar’s Forge Planner">
+        <span class="mark" aria-hidden="true"><img src="images/ico.png" alt=""/></span>
+        <span>Scholar’s Forge Planner</span>
+      </a>
+      <div class="links">
+        <a href="https://www.blogger.com" target="_blank" rel="noopener">Blog</a>
+        <a href="/about.html">About Us</a>
+        <a href="/contact.html">Contact Us</a>
+        <div class="mode-switch" role="tablist" aria-label="Theme mode">
+          <button id="mode-scholar" role="tab" aria-selected="true">Scholar</button>
+          <button id="mode-forge" role="tab" aria-selected="false">Forge</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section class="container" id="contact" aria-labelledby="contact-title">
+      <br>
+      <h1 id="contact-title">Contact Us</h1>
+      <p class="muted">Conference organizers, co-ops, and partners, we’d love to connect. Speaking opportunities welcome.</p>
+      <p><a href="mailto:support@scholarsforge.com">support@scholarsforge.com</a></p>
+      <br>
+      <br>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container foot">
+      <div class="brand"><span class="mark" aria-hidden="true"><img src="images/ico.png" alt=""/></span><span>Scholar’s Forge Planner</span></div>
+      <div>
+        <a href="https://www.blogger.com" target="_blank" rel="noopener">Blog</a><span class="sep"> • </span>
+        <a href="/about.html">About Us</a><span class="sep"> • </span>
+        <a href="/contact.html">Contact Us</a>
+      </div>
+      <div>© <span id="year"></span> Scholar’s Forge LLC. All rights reserved.</div>
+    </div>
+  </footer>
+
+  <script src="landing.js"></script>
+  <script>document.getElementById('year').textContent=new Date().getFullYear();</script>
+  <script>
+/* Segmented “Scholar / Forge” toggle → persist user choice */
+(function () {
+  var KEY = 'sf_theme';
+  var root = document.documentElement;
+  var bScholar = document.getElementById('mode-scholar');
+  var bForge   = document.getElementById('mode-forge');
+
+  function setMode(mode, persist) {
+    root.setAttribute('data-theme', mode);
+    if (persist) {
+      try { localStorage.setItem(KEY, mode); } catch(_) {}
+    }
+    if (bScholar && bForge) {
+      bScholar.classList.toggle('active', mode === 'scholar');
+      bForge.classList.toggle('active',   mode === 'forge');
+      bScholar.setAttribute('aria-selected', mode === 'scholar');
+      bForge.setAttribute('aria-selected',   mode === 'forge');
+    }
+  }
+
+  if (bScholar) bScholar.addEventListener('click', function(){ setMode('scholar', true); });
+  if (bForge)   bForge.addEventListener('click',   function(){ setMode('forge',   true); });
+
+  // Ensure the segmented control reflects whatever the head script chose
+  setMode(root.getAttribute('data-theme') || 'scholar', false);
+})();
+  </script>
+</body>
+</html>
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -207,16 +207,14 @@
         <span>Scholar’s Forge Planner</span>
       </a>
       <div class="links">
-        <a href="#how">How it works</a>
-        <a href="#features">Features</a>
-        <a href="#pricing">Pricing</a>
+        <a href="https://www.blogger.com" target="_blank" rel="noopener">Blog</a>
+        <a href="/about.html">About Us</a>
+        <a href="/contact.html">Contact Us</a>
         <!-- Segmented mode switch -->
         <div class="mode-switch" role="tablist" aria-label="Theme mode">
           <button id="mode-scholar" role="tab" aria-selected="true">Scholar</button>
           <button id="mode-forge" role="tab" aria-selected="false">Forge</button>
         </div>
-        <!-- Direct link to Week Preview demo; use docs path so it resolves from root -->
-        <a class="btn primary" href="/docs/week.html">See mobile preview</a>
       </div>
     </div>
   </header>
@@ -366,9 +364,9 @@
     <div class="container foot">
       <div class="brand"><span class="mark" aria-hidden="true"><img src="images/ico.png" alt=""/></span><span>Scholar’s Forge Planner</span></div>
       <div>
-        <a href="#how">How it works</a><span class="sep"> • </span>
-        <a href="#features">Features</a><span class="sep"> • </span>
-        <a href="#pricing">Pricing</a>
+        <a href="https://www.blogger.com" target="_blank" rel="noopener">Blog</a><span class="sep"> • </span>
+        <a href="/about.html">About Us</a><span class="sep"> • </span>
+        <a href="/contact.html">Contact Us</a>
       </div>
       <div>© <span id="year"></span> Scholar’s Forge LLC. All rights reserved.</div>
     </div>


### PR DESCRIPTION
## Summary
- replace marketing navigation links with Blog, About Us, Contact Us
- mirror changes in docs marketing pages
- add placeholder Contact Us pages with email info

## Testing
- `~/.dotnet/dotnet build`
- `~/.dotnet/dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c1f1446ed4832ebb92378d8f4af3b2