### PR TITLE
Limit beta pricing tiers and disable trial buttons

### DIFF
--- a/AgentNotes/2025-09-08T01-46-54Z-marketing-refresh.md
+++ b/AgentNotes/2025-09-08T01-46-54Z-marketing-refresh.md
@@ -62,3 +62,11 @@ Refine the marketing home page per client: more whitespace, real carousel, light
 * Replaced "hello@scholarsforge.app" with `support@scholarsforge.com` in marketing and docs landing pages.
 * `dotnet build` and `dotnet test` succeeded.
 * Confidence: 0.93
+## Follow-up (2025-09-10 21:48 UTC)
+* Update beta testing pricing section to only show "Family (unlimited children)" and "Pro (charters and co-ops)" tiers.
+* Change start free trial buttons to read "coming soon", greyed out, and disabled.
+## Results (2025-09-10 21:54 UTC)
+* Pricing section now only lists Family (unlimited children) and Pro (charters and co-ops) tiers with greyed "Coming soon" buttons.
+* Added disabled button styling to marketing and docs CSS.
+* Attempted `dotnet build`/`test`, but `dotnet` SDK unavailable; install attempt failed.
+* Confidence: 0.84

--- a/HomeschoolPlanner.Api/wwwroot/marketing/landing.css
+++ b/HomeschoolPlanner.Api/wwwroot/marketing/landing.css
@@ -48,6 +48,7 @@ header{position:sticky;top:0;z-index:10;background:rgba(14,15,18,.6);backdrop-fi
 .btn{display:inline-flex;align-items:center;justify-content:center;padding:.85rem 1.1rem;border-radius:12px;border:1px solid #2a3244;font-weight:800}
 .btn.primary{background:linear-gradient(180deg,#7aa2ff,#547dff);color:var(--ctaText);border-color:#688fff}
 .btn.ghost{background:transparent;color:var(--fg)}
+.btn.disabled{background:#d3d3d3;color:#666;border-color:#bbb;cursor:not-allowed;pointer-events:none}
 /* Hero */
 section{padding:72px 0;border-top:1px solid #1a1f2b}
 .hero{display:grid;gap:28px;grid-template-columns:1.1fr 1fr;align-items:center}

--- a/docs/index.html
+++ b/docs/index.html
@@ -350,10 +350,9 @@
     <section class="container" id="pricing" aria-labelledby="pricing-title">
       <br>
       <h2 id="pricing-title">Simple, transparent pricing</h2>
-      <div class="grid-3">
-        <div class="card"><h3>🧑‍🎓Starter</h3><p class="muted">One learner. All core features.</p><a class="btn primary" href="#signup">Start free trial</a></div>
-        <div class="card"><h3>👨‍👩‍👧‍👦Family</h3><p class="muted">Up to five learners.</p><a class="btn primary" href="#signup">Start free trial</a></div>
-        <div class="card"><h3>🏫Pro</h3><p class="muted">Co-ops & large families.</p><a class="btn primary" href="#signup">Start free trial</a></div>
+      <div class="grid-2">
+        <div class="card"><h3>👨‍👩‍👧‍👦 Family (unlimited children)</h3><span class="btn disabled" aria-disabled="true">Coming soon</span></div>
+        <div class="card"><h3>🏫 Pro (charters and co-ops)</h3><span class="btn disabled" aria-disabled="true">Coming soon</span></div>
       </div>
       <p class="muted" style="margin-top:12px">No credit card required to start. Cancel anytime.</p>
       <br>

--- a/docs/landing.css
+++ b/docs/landing.css
@@ -47,6 +47,7 @@ header{position:sticky;top:0;z-index:10;background:rgba(255,255,255,.6);backdrop
 .pill{padding:.55rem .8rem;border:1px dashed #d7d1cc;border-radius:999px;background:#fffdfb}
 .btn.primary{background:linear-gradient(180deg,#7aa2ff,#547dff);color:var(--ctaText);border:1px solid #688fff;border-radius:12px;padding:.9rem 1.1rem;font-weight:800}
 .btn.ghost{border:1px solid var(--border);border-radius:12px;padding:.9rem 1.1rem}
+.btn.disabled{display:inline-block;background:#d3d3d3;color:#666;border:1px solid #bbb;border-radius:12px;padding:.9rem 1.1rem;font-weight:800;cursor:not-allowed;pointer-events:none}
 .carousel .slide{min-height:340px}
 .beta-form{display:flex;gap:.6rem;margin-top:1rem}
 .beta-form input{flex:1;padding:.8rem 1rem;border:1px solid var(--border);border-radius:12px;font-size:1rem}


### PR DESCRIPTION
## Summary
- show only Family and Pro beta tiers
- greyed out Coming soon buttons for pricing

## Testing
- `dotnet build` *(command not found)*
- `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f1f799ec832eb7af9ffea13f9aad