### PR TITLE
Point navbar brand to index page

### DIFF
--- a/AgentNotes/2025-09-10T22-35-39Z-index-link.md
+++ b/AgentNotes/2025-09-10T22-35-39Z-index-link.md
@@ -1,0 +1,15 @@
+## Task
+Change navbar "Scholar's Forge Planner" link to point to index page instead of site root.
+
+## Initial considerations
+* Brand links in docs and marketing pages use `href="/"`, but root doesn't resolve to page.
+* Need to update both icon and text link anchors to `index.html`.
+* After changes run `dotnet build` and `dotnet test`.
+## Follow-up (2025-09-10 22:42 UTC)
+* Updated brand anchors in docs and marketing pages to `index.html` with explanatory comments.
+* Installed .NET SDK and ran `dotnet build` and `dotnet test` to verify changes.
+
+## Results
+* Brand text and icon now navigate to the index page, avoiding broken root links.
+* `dotnet build` and `dotnet test` both succeeded.
+* Confidence: 0.88

--- a/HomeschoolPlanner.Api/wwwroot/marketing/contact.html
+++ b/HomeschoolPlanner.Api/wwwroot/marketing/contact.html
@@ -45,9 +45,10 @@
   <link rel="stylesheet" href="landing.css"/>
 </head>
 <body>
-  <header>
+<header>
     <div class="container nav">
-      <a class="logo" href="/"><span class="logo-mark"></span>Homeschool Planner</a>
+      <!-- Brand logo should link back to marketing index page -->
+      <a class="logo" href="index.html"><span class="logo-mark"></span>Homeschool Planner</a>
       <nav>
         <a href="https://www.blogger.com" target="_blank" rel="noopener">Blog</a>
         <a href="about.html">About Us</a>

--- a/HomeschoolPlanner.Api/wwwroot/marketing/index.html
+++ b/HomeschoolPlanner.Api/wwwroot/marketing/index.html
@@ -47,7 +47,8 @@
 <!-- Main marketing landing page -->
 <header>
   <div class="container nav">
-    <a class="logo" href="/"><span class="logo-mark"></span>Homeschool Planner</a>
+    <!-- Ensure brand logo links to marketing index -->
+    <a class="logo" href="index.html"><span class="logo-mark"></span>Homeschool Planner</a>
     <nav>
       <a href="https://www.blogger.com" target="_blank" rel="noopener">Blog</a>
       <a href="about.html">About Us</a>

--- a/docs/contact.html
+++ b/docs/contact.html
@@ -49,7 +49,8 @@
 <body>
   <header>
     <div class="container nav" role="navigation" aria-label="Primary">
-      <a class="brand" href="/" aria-label="Scholar’s Forge Planner">
+      <!-- Brand link points to index rather than site root -->
+      <a class="brand" href="index.html" aria-label="Scholar’s Forge Planner">
         <span class="mark" aria-hidden="true"><img src="images/ico.png" alt=""/></span>
         <span>Scholar’s Forge Planner</span>
       </a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -52,7 +52,8 @@
   <!-- NAV -->
   <header>
     <div class="container nav" role="navigation" aria-label="Primary">
-      <a class="brand" href="/" aria-label="Scholar’s Forge Planner">
+      <!-- Brand link explicitly targets index to avoid missing root config -->
+      <a class="brand" href="index.html" aria-label="Scholar’s Forge Planner">
         <span class="mark" aria-hidden="true"><img src="images/ico.png" alt=""/></span>
         <span>Scholar’s Forge Planner</span>
       </a>


### PR DESCRIPTION
## Summary
- Ensure marketing and docs navbar brand links target `index.html` to avoid broken root links

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68c1fd183a70832ea8db485f3b1ff457