### PR TITLE
Handle missing Graph mail configuration

### DIFF
--- a/Startup.fs
+++ b/Startup.fs
@@ -83,21 +83,25 @@ app.MapPost(
 <p><strong>Message:</strong><br/>{encodeMultiline message}</p>
 """
 
-                try
-                    do!
-                        Graph.sendEmail
-                            "support@scholarsforge.com"
-                            [ "support@scholarsforge.com" ]
-                            subject
-                            body
-                            true
-                            [ email ]
-                        |> Async.StartAsTask
+                if Graph.isConfigured () then
+                    try
+                        do!
+                            Graph.sendEmail
+                                "support@scholarsforge.com"
+                                [ "support@scholarsforge.com" ]
+                                subject
+                                body
+                                true
+                                [ email ]
+                            |> Async.StartAsTask
 
-                    ctx.Response.Redirect("/")
-                with _ ->
-                    ctx.Response.StatusCode <- StatusCodes.Status500InternalServerError
-                    do! ctx.Response.WriteAsync("We were unable to send your message. Please try again later.")
+                        ctx.Response.Redirect("/")
+                    with _ ->
+                        ctx.Response.StatusCode <- StatusCodes.Status500InternalServerError
+                        do! ctx.Response.WriteAsync("We were unable to send your message. Please try again later.")
+                else
+                    ctx.Response.StatusCode <- StatusCodes.Status503ServiceUnavailable
+                    do! ctx.Response.WriteAsync("Our email service is not configured. Please try again later.")
 
             return ()
         }


### PR DESCRIPTION
## Summary
- add configuration helper that resolves Graph client values from multiple environment variable names
- expose a Graph.isConfigured guard so the contact form handler can detect missing configuration
- short-circuit contact form submission when email delivery is not configured instead of throwing a null secret exception

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68d426a5c928832e85d273746d8e823e