### PR TITLE
Add themed background hero for Contact page

### DIFF
--- a/StaticPages.fs
+++ b/StaticPages.fs
@@ -680,139 +680,142 @@ module ContactPage =
     let view =
         main {
             section {
-                class' "container"
+                class' "contact-hero"
                 id "contact"
                 "aria-labelledby", "contact-title"
                 div {
-                    class' "card contact-card"
-                    h1 { id "contact-title"; "Contact Us" }
-                    p {
-                        class' "muted"
-                        "Let’s connect! Families, co-ops, teachers, or anyone interested — reach out with your questions or ideas."
-                    }
-                    form {
-                        class' "contact-form"
-                        method "post"
-                        action "/contact/send"
-                        div {
-                            class' "contact-form-main"
-                            div {
-                                class' "contact-column"
-                                div {
-                                    class' "contact-field"
-                                    label {
-                                        "for", "first-name"
-                                        "First name"
-                                    }
-                                    input {
-                                        id "first-name"
-                                        "name", "firstName"
-                                        type' "text"
-                                        "autocomplete", "given-name"
-                                        "required", ""
-                                    }
-                                }
-                                div {
-                                    class' "contact-field"
-                                    label {
-                                        "for", "telephone"
-                                        "Telephone"
-                                    }
-                                    input {
-                                        id "telephone"
-                                        "name", "telephone"
-                                        type' "tel"
-                                        "autocomplete", "tel"
-                                        "required", ""
-                                    }
-                                }
-                                div {
-                                    class' "contact-field"
-                                    label {
-                                        "for", "title"
-                                        span { "Title" }
-                                        span { class' "optional"; "Optional" }
-                                    }
-                                    input {
-                                        id "title"
-                                        "name", "title"
-                                        type' "text"
-                                        "autocomplete", "organization-title"
-                                    }
-                                }
-                            }
-                            div {
-                                class' "contact-column"
-                                div {
-                                    class' "contact-field"
-                                    label {
-                                        "for", "last-name"
-                                        "Last name"
-                                    }
-                                    input {
-                                        id "last-name"
-                                        "name", "lastName"
-                                        type' "text"
-                                        "autocomplete", "family-name"
-                                        "required", ""
-                                    }
-                                }
-                                div {
-                                    class' "contact-field"
-                                    label {
-                                        "for", "email"
-                                        "Email"
-                                    }
-                                    input {
-                                        id "email"
-                                        "name", "email"
-                                        type' "email"
-                                        "autocomplete", "email"
-                                        "required", ""
-                                    }
-                                }
-                                div {
-                                    class' "contact-field"
-                                    label {
-                                        "for", "company"
-                                        span { "Company" }
-                                        span { class' "optional"; "Optional" }
-                                    }
-                                    input {
-                                        id "company"
-                                        "name", "company"
-                                        type' "text"
-                                        "autocomplete", "organization"
-                                    }
-                                }
-                            }
+                    class' "container contact-hero-content"
+                    div {
+                        class' "card contact-card"
+                        h1 { id "contact-title"; "Contact Us" }
+                        p {
+                            class' "muted"
+                            "Let’s connect! Families, co-ops, teachers, or anyone interested — reach out with your questions or ideas."
                         }
-                        div {
-                            class' "contact-form-message"
+                        form {
+                            class' "contact-form"
+                            method "post"
+                            action "/contact/send"
                             div {
-                                class' "contact-field"
-                                label {
-                                    "for", "message"
-                                    "Message"
+                                class' "contact-form-main"
+                                div {
+                                    class' "contact-column"
+                                    div {
+                                        class' "contact-field"
+                                        label {
+                                            "for", "first-name"
+                                            "First name"
+                                        }
+                                        input {
+                                            id "first-name"
+                                            "name", "firstName"
+                                            type' "text"
+                                            "autocomplete", "given-name"
+                                            "required", ""
+                                        }
+                                    }
+                                    div {
+                                        class' "contact-field"
+                                        label {
+                                            "for", "telephone"
+                                            "Telephone"
+                                        }
+                                        input {
+                                            id "telephone"
+                                            "name", "telephone"
+                                            type' "tel"
+                                            "autocomplete", "tel"
+                                            "required", ""
+                                        }
+                                    }
+                                    div {
+                                        class' "contact-field"
+                                        label {
+                                            "for", "title"
+                                            span { "Title" }
+                                            span { class' "optional"; "Optional" }
+                                        }
+                                        input {
+                                            id "title"
+                                            "name", "title"
+                                            type' "text"
+                                            "autocomplete", "organization-title"
+                                        }
+                                    }
                                 }
-                                textarea {
-                                    id "message"
-                                    "name", "message"
-                                    "rows", "6"
-                                    "required", ""
+                                div {
+                                    class' "contact-column"
+                                    div {
+                                        class' "contact-field"
+                                        label {
+                                            "for", "last-name"
+                                            "Last name"
+                                        }
+                                        input {
+                                            id "last-name"
+                                            "name", "lastName"
+                                            type' "text"
+                                            "autocomplete", "family-name"
+                                            "required", ""
+                                        }
+                                    }
+                                    div {
+                                        class' "contact-field"
+                                        label {
+                                            "for", "email"
+                                            "Email"
+                                        }
+                                        input {
+                                            id "email"
+                                            "name", "email"
+                                            type' "email"
+                                            "autocomplete", "email"
+                                            "required", ""
+                                        }
+                                    }
+                                    div {
+                                        class' "contact-field"
+                                        label {
+                                            "for", "company"
+                                            span { "Company" }
+                                            span { class' "optional"; "Optional" }
+                                        }
+                                        input {
+                                            id "company"
+                                            "name", "company"
+                                            type' "text"
+                                            "autocomplete", "organization"
+                                        }
+                                    }
                                 }
                             }
-                        }
-                        //div {
-                        //    class' "contact-recaptcha"
-                        //    id "contact-recaptcha"
-                        //}
-                        div {
-                            class' "contact-submit"
-                            button {
-                                class' "btn primary"
-                                type' "submit"
-                                "Send"
+                            div {
+                                class' "contact-form-message"
+                                div {
+                                    class' "contact-field"
+                                    label {
+                                        "for", "message"
+                                        "Message"
+                                    }
+                                    textarea {
+                                        id "message"
+                                        "name", "message"
+                                        "rows", "6"
+                                        "required", ""
+                                    }
+                                }
+                            }
+                            //div {
+                            //    class' "contact-recaptcha"
+                            //    id "contact-recaptcha"
+                            //}
+                            div {
+                                class' "contact-submit"
+                                button {
+                                    class' "btn primary"
+                                    type' "submit"
+                                    "Send"
+                                }
                             }
                         }
                     }

--- a/wwwroot/landing.css
+++ b/wwwroot/landing.css
@@ -1,6 +1,11 @@
 /* =========================
    THEME TOKENS
    ========================= */
+:root {
+    --contact-hero-image: none;
+    --contact-hero-overlay: none;
+}
+
 :root[data-theme="scholar"] {
     --bg: #f9f6f3;
     --paper: #ffffff;
@@ -17,6 +22,8 @@
     --gutter: 28px;
     --maxw: 1200px;
     --ctaText: #fff;
+    --contact-hero-image: url('images/ContactBackground_L.png');
+    --contact-hero-overlay: linear-gradient(180deg, rgba(249,246,243,.92) 0%, rgba(249,246,243,.82) 35%, rgba(249,246,243,.9) 100%);
 }
 
 :root[data-theme="forge"] {
@@ -35,6 +42,8 @@
     --gutter: 28px;
     --maxw: 1200px;
     --ctaText: #000;
+    --contact-hero-image: url('images/ContactBackground_D.png');
+    --contact-hero-overlay: linear-gradient(180deg, rgba(8,7,12,.82) 0%, rgba(8,7,12,.76) 42%, rgba(12,10,16,.72) 100%);
 }
 
 /* =========================
@@ -610,9 +619,38 @@ footer {
     padding: clamp(56px, 8vw, 108px) 0 clamp(72px, 9vw, 120px);
 }
 
+.contact-hero {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    background: color-mix(in oklab, var(--paper) 82%, var(--tint));
+}
+
+.contact-hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    background-image: var(--contact-hero-overlay), var(--contact-hero-image);
+    background-size: cover, cover;
+    background-position: center, center;
+    background-repeat: no-repeat;
+    transform: scale(1.02);
+    filter: saturate(1.02);
+}
+
+.contact-hero-content {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    justify-content: center;
+}
+
 .contact-card {
     display: grid;
     gap: 1.8rem;
+    width: min(100%, 880px);
 }
 
 .contact-form {


### PR DESCRIPTION
## Summary
- wrap the Contact page content in a dedicated hero container so the form sits above a background treatment
- define theme-specific background assets and overlays so the contact hero swaps images between Scholar and Forge modes
- center the contact card and limit its max width for a balanced layout

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68d573d9d204832e829bc1de76d408eb